### PR TITLE
expose the function to calculate transform matrix

### DIFF
--- a/python/kachaka_api/geometry_util.py
+++ b/python/kachaka_api/geometry_util.py
@@ -6,12 +6,14 @@ import numpy as np
 from .generated.kachaka_api_pb2 import Map, Pose
 
 
-def _transform_matrix(tx: float, ty: float, theta: float = 0) -> np.ndarray:
+def calculate_2d_transform_matrix(
+    tx: float, ty: float, theta: float = 0
+) -> np.ndarray:
     c, s = cos(theta), sin(theta)
     return np.array(((c, -s, tx), (s, c, ty), (0, 0, 1)))
 
 
-def _scale_matrix(sx: float, sy: float) -> np.ndarray:
+def calculate_2d_scale_matrix(sx: float, sy: float) -> np.ndarray:
     return np.array(((sx, 0, 0), (0, sy, 0), (0, 0, 1)))
 
 
@@ -20,9 +22,9 @@ class MapImage2DGeometry:
         resolution = png_map.resolution
         origin = png_map.origin
         self._map_to_image_origin = (
-            _transform_matrix(origin.x, origin.y, origin.theta)
-            @ _scale_matrix(resolution, -resolution)
-            @ _transform_matrix(0.5, -png_map.height + 0.5)
+            calculate_2d_transform_matrix(origin.x, origin.y, origin.theta)
+            @ calculate_2d_scale_matrix(resolution, -resolution)
+            @ calculate_2d_transform_matrix(0.5, -png_map.height + 0.5)
         )
         self._image_origin_to_map = np.linalg.inv(self._map_to_image_origin)
 
@@ -34,7 +36,7 @@ class MapImage2DGeometry:
         :param robot_pose: ロボット姿勢 [m, m, rad]
         :returns 3x3 行列
         """
-        return self._image_origin_to_map @ _transform_matrix(
+        return self._image_origin_to_map @ calculate_2d_transform_matrix(
             robot_pose.x, robot_pose.y, robot_pose.theta
         )
 
@@ -47,4 +49,6 @@ class MapImage2DGeometry:
         :param angle: 半時計周りを正とする角度 [radian]
         :returns 3x3 行列
         """
-        return self._map_to_image_origin @ _transform_matrix(*pixel_xy, angle)
+        return self._map_to_image_origin @ calculate_2d_transform_matrix(
+            *pixel_xy, angle
+        )


### PR DESCRIPTION
従来、MapImage2DGeometryの中で行列を変換する処理を隠蔽していました。しかし複数のベクトルを同時に変換するなどの行列をそのまま使いたいケースがあるのでpublicな名前にしたいです。