### PR TITLE
Add get_auto_homing_enabled to kachaka-api

### DIFF
--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -282,6 +282,11 @@ class KachakaApiClientBase:
         response = await self.stub.SetAutoHomingEnabled(request)
         return response.result
 
+    async def get_auto_homing_enabled(self):
+        request = pb2.GetRequest()
+        response = await self.stub.GetAutoHomingEnabled(request)
+        return response.enabled
+
     async def set_manual_control_enabled(self, enable: bool):
         request = pb2.SetManualControlEnabledRequest(enable=enable)
         response = await self.stub.SetManualControlEnabled(request)

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -285,6 +285,11 @@ class KachakaApiClientBase:
         response = self.stub.SetAutoHomingEnabled(request)
         return response.result
 
+    def get_auto_homing_enabled(self):
+        request = pb2.GetRequest()
+        response = self.stub.GetAutoHomingEnabled(request)
+        return response.enabled
+
     def set_manual_control_enabled(self, enable: bool):
         request = pb2.SetManualControlEnabledRequest(enable=enable)
         response = self.stub.SetManualControlEnabled(request)


### PR DESCRIPTION
get_auto_homing_enabledがkachaka-apiに欠けていたので足します。
改めて確認しましたが、欠けていたのはこれだけでした