### PR TITLE
fixed field name to get robot version

### DIFF
--- a/python/kachaka_api/aio/__init__.py
+++ b/python/kachaka_api/aio/__init__.py
@@ -171,7 +171,7 @@ class KachakaApiClient(KachakaApiClientBase):
             response = await self.stub.GetRobotVersion(request)
             self.get_robot_version_cursor = response.metadata.cursor
 
-            self._robot_version = response.robot_version
+            self._robot_version = response.version
             assert self._robot_version is not None
 
             if self._robot_version_callback:


### PR DESCRIPTION
```
message GetRobotVersionResponse {
  Metadata metadata = 1;
  string version = 2;
}
```

なので、`response.version`を取得するところが`response.robot_version`となっていたので修正します。