### PR TITLE
Fix url api demo

### DIFF
--- a/python/demos/url_kachaka_api.ipynb
+++ b/python/demos/url_kachaka_api.ipynb
@@ -72,7 +72,7 @@
     "from google.protobuf.json_format import MessageToDict\n",
     "\n",
     "app = FastAPI()\n",
-    "kachaka_client = kachaka_api.aio.KachakaApiClient(\"192.168.1.202:26400\")\n",
+    "kachaka_client = kachaka_api.aio.KachakaApiClient(kachaka_api_server)\n",
     "\n",
     "\n",
     "@app.on_event(\"startup\")\n",


### PR DESCRIPTION
すみません、手元で動作確認したpythonをコピペしたときにローカルのURLが残ってました:bow: