### PR TITLE
Refactor and mypy to kachaka_api/aio/__init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ excludes = [
 [[tool.pysen.lint.mypy_targets]]
 paths = [
     "python/kachaka_api/base.py",
-    "python/kachaka_api/aio/base.py",
+    "python/kachaka_api/aio/",
+    "python/demos/sample_llm_speak.py",
 ]
 
 [tool.pysen.plugin.clang_format]

--- a/python/demos/sample_llm_speak.py
+++ b/python/demos/sample_llm_speak.py
@@ -59,8 +59,8 @@ def ask_chatgpt(system: str, prompt: str) -> str:
             {"role": "system", "content": system},
             {"role": "user", "content": prompt},
         ],
-    )
-    return result["choices"][0]["message"]["content"]
+    )  # type: ignore
+    return result["choices"][0]["message"]["content"]  # type: ignore
 
 
 def generate_speak_text(history: list[KachakaCommandRecord]) -> str:
@@ -96,7 +96,9 @@ async def main() -> None:
     async def on_locations(locations: list[pb2.Location]) -> None:
         client.resolver.set_locations(locations)
 
-    async def on_command_result(result, command):
+    async def on_command_result(
+        result: pb2.Result, command: pb2.Command
+    ) -> None:
         nonlocal skip
         if skip:
             print("command result before this script launched was skipped")

--- a/python/kachaka_api/aio/__init__.py
+++ b/python/kachaka_api/aio/__init__.py
@@ -86,13 +86,13 @@ class KachakaApiClient(KachakaApiClientBase):
         super().__init__(target)
         self._running = True
 
-        self.robot_pose: ResponseHandler[
-            pb2.GetRobotPoseResponse, pb2.Pose
-        ] = ResponseHandler(self.stub.GetRobotPose, lambda r: r.pose)
-
         self.png_map: ResponseHandler[
             pb2.GetPngMapResponse, pb2.Map
         ] = ResponseHandler(self.stub.GetPngMap, lambda r: r.map)
+
+        self.robot_pose: ResponseHandler[
+            pb2.GetRobotPoseResponse, pb2.Pose
+        ] = ResponseHandler(self.stub.GetRobotPose, lambda r: r.pose)
 
         self.object_detection: TupleResponseHandler[
             pb2.GetObjectDetectionResponse,
@@ -140,13 +140,17 @@ class KachakaApiClient(KachakaApiClientBase):
             self.stub.GetLastCommandResult, lambda r: (r.result, r.command)
         )
 
+        self.shelves: ResponseHandler[
+            pb2.GetShelvesResponse, RepeatedCompositeContainer
+        ] = ResponseHandler(self.stub.GetShelves, lambda r: r.shelves)
+
         self.locations: ResponseHandler[
             pb2.GetLocationsResponse, RepeatedCompositeContainer
         ] = ResponseHandler(self.stub.GetLocations, lambda r: r.locations)
 
-        self.shelves: ResponseHandler[
-            pb2.GetShelvesResponse, RepeatedCompositeContainer
-        ] = ResponseHandler(self.stub.GetShelves, lambda r: r.shelves)
+        self.history_list: ResponseHandler[
+            pb2.GetHistoryListResponse, RepeatedCompositeContainer
+        ] = ResponseHandler(self.stub.GetHistoryList, lambda r: r.histories)
 
         self.auto_homing_enabled: ResponseHandler[
             pb2.GetAutoHomingEnabledResponse, bool
@@ -158,15 +162,11 @@ class KachakaApiClient(KachakaApiClientBase):
             self.stub.GetManualControlEnabled, lambda r: r.enabled
         )
 
-        self.history_list: ResponseHandler[
-            pb2.GetHistoryListResponse, RepeatedCompositeContainer
-        ] = ResponseHandler(self.stub.GetHistoryList, lambda r: r.histories)
+    def set_png_map_callback(self, callback: CallbackType[pb2.Map]) -> None:
+        self.png_map.set_callback(callback)
 
     def set_robot_pose_callback(self, callback: CallbackType[pb2.Pose]) -> None:
         self.robot_pose.set_callback(callback)
-
-    def set_png_map_callback(self, callback: CallbackType[pb2.Map]) -> None:
-        self.png_map.set_callback(callback)
 
     def set_object_detection_callback(
         self,
@@ -214,21 +214,26 @@ class KachakaApiClient(KachakaApiClientBase):
     ) -> None:
         self.command_state.set_tuple_callback(callback)
 
-    def set_locations_callback(
-        self, callback: CallbackType[RepeatedCompositeContainer]
+    def set_last_command_result_callback(
+        self,
+        callback: Callable[[pb2.Result, pb2.Command], Awaitable[None]] | None,
     ) -> None:
-        self.locations.set_callback(callback)
+        self.last_command_result.set_tuple_callback(callback)
 
     def set_shelves_callback(
         self, callback: CallbackType[RepeatedCompositeContainer]
     ) -> None:
         self.shelves.set_callback(callback)
 
-    def set_last_command_result_callback(
-        self,
-        callback: Callable[[pb2.Result, pb2.Command], Awaitable[None]] | None,
+    def set_locations_callback(
+        self, callback: CallbackType[RepeatedCompositeContainer]
     ) -> None:
-        self.last_command_result.set_tuple_callback(callback)
+        self.locations.set_callback(callback)
+
+    def set_history_list_callback(
+        self, callback: CallbackType[RepeatedCompositeContainer]
+    ) -> None:
+        self.history_list.set_callback(callback)
 
     def set_auto_homing_enabled_callback(
         self, callback: CallbackType[bool]
@@ -239,8 +244,3 @@ class KachakaApiClient(KachakaApiClientBase):
         self, callback: CallbackType[bool]
     ) -> None:
         self.manual_control_enabled.set_callback(callback)
-
-    def set_history_list_callback(
-        self, callback: CallbackType[RepeatedCompositeContainer]
-    ) -> None:
-        self.history_list.set_callback(callback)

--- a/python/kachaka_api/aio/__init__.py
+++ b/python/kachaka_api/aio/__init__.py
@@ -13,33 +13,81 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Optional, Tuple
-
-from ..generated.kachaka_api_pb2 import (
-    Command,
-    CommandState,
-    GetRequest,
-    History,
-    Location,
-    Map,
-    Metadata,
-    ObjectDetection,
-    Pose,
-    Result,
-    RosCameraInfo,
-    RosCompressedImage,
-    RosHeader,
-    RosImage,
-    RosImu,
-    RosLaserScan,
-    RosOdometry,
-    Shelf,
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Generic,
+    ParamSpec,
+    Protocol,
+    TypeVar,
 )
+
+from google._upb._message import RepeatedCompositeContainer
+
+from ..generated import kachaka_api_pb2 as pb2
 from .base import KachakaApiClientBase
 
 
-def build_get_request(cursor: int) -> GetRequest:
-    return GetRequest(metadata=Metadata(cursor=cursor))
+def build_get_request(cursor: int) -> pb2.GetRequest:
+    return pb2.GetRequest(metadata=pb2.Metadata(cursor=cursor))
+
+
+class HasMetadata(Protocol):
+    metadata: pb2.Metadata
+
+
+T = TypeVar("T", bound=HasMetadata)
+U = TypeVar("U")
+V = TypeVar("V", bound=tuple[Any, ...])
+P = ParamSpec("P")
+CallbackType = Callable[[U], Awaitable[None]] | None
+
+
+class ResponseHandler(Generic[T, U]):
+    def __init__(
+        self,
+        get_function: Callable[[pb2.GetRequest], Awaitable[T]],
+        pick_response: Callable[[T], U],
+    ) -> None:
+        self.callback: CallbackType[U] = None
+        self.get_function = get_function
+        self.pick_response = pick_response
+
+    async def _run(self) -> None:
+        cursor = 0
+        while self.callback is not None:
+            request = build_get_request(cursor)
+            response = await self.get_function(request)
+            cursor = response.metadata.cursor
+            if self.callback is not None:
+                picked_response = self.pick_response(response)
+                await self.callback(picked_response)
+
+    def set_callback(self, callback: CallbackType[U]) -> None:
+        if self.callback is not None and callback is not None:
+            raise RuntimeError("Callback is already set")
+        self.callback = callback
+        if callback is not None:
+            asyncio.create_task(self._run())
+
+
+class TupleResponseHandler(ResponseHandler[T, U], Generic[T, U, P]):
+    def set_tuple_callback(
+        self, callback: Callable[P, Awaitable[None]] | None
+    ) -> None:
+        if self.callback is not None and callback is not None:
+            raise RuntimeError("Callback is already set")
+        if callback is None:
+            self.callback = None
+            return
+
+        def extract_tuple_and_run(args: U) -> Awaitable[None]:
+            assert isinstance(args, tuple)
+            return callback(*args)
+
+        self.callback = extract_tuple_and_run
+        asyncio.create_task(self._run())
 
 
 class KachakaApiClient(KachakaApiClientBase):
@@ -47,507 +95,161 @@ class KachakaApiClient(KachakaApiClientBase):
         super().__init__(target)
         self._running = True
 
-        self.get_robot_serial_number_cursor = 0
-        self.get_robot_version_cursor = 0
-        self.get_robot_pose_cursor = 0
-        self.get_png_map_cursor = 0
-        self.get_object_detection_cursor = 0
-        self.get_ros_imu_cursor = 0
-        self.get_ros_odometry_cursor = 0
-        self.get_ros_laser_scan_cursor = 0
-        self.get_front_camera_ros_camera_info_cursor = 0
-        self.get_front_camera_ros_image_cursor = 0
-        self.get_front_camera_ros_compressed_image_cursor = 0
-        self.get_command_state_cursor = 0
-        self.get_last_command_result_cursor = 0
-        self.get_locations_cursor = 0
-        self.get_default_location_id_cursor = 0
-        self.get_shelves_cursor = 0
-        self.get_auto_homing_enabled_cursor = 0
-        self.get_manual_control_enabled_cursor = 0
-        self.get_history_list_cursor = 0
+        self.robot_pose: ResponseHandler[
+            pb2.GetRobotPoseResponse, pb2.Pose
+        ] = ResponseHandler(self.stub.GetRobotPose, lambda r: r.pose)
 
-        self._robot_serial_number: Optional[str] = None
-        self._robot_serial_number_callback: Optional[
-            callable[[str], Awaitable[None]]
-        ] = None
-        self._robot_version: Optional[str] = None
-        self._robot_version_callback: Optional[
-            callable[[str], Awaitable[None]]
-        ] = None
-        self._robot_pose: Optional[Pose] = None
-        self._robot_pose_callback: Optional[
-            callable[[Pose], Awaitable[None]]
-        ] = None
-        self._png_map: Optional[Map] = None
-        self._png_map_callback: Optional[
-            callable[[Map], Awaitable[None]]
-        ] = None
-        self._object_detection: Optional[
-            Tuple[RosHeader, list[ObjectDetection]]
-        ] = None
-        self._object_detection_callback: Optional[
-            callable[[RosHeader, list[ObjectDetection]], Awaitable[None]]
-        ] = None
-        self._ros_imu: Optional[RosImu] = None
-        self._ros_imu_callback: Optional[
-            callable[[RosImu], Awaitable[None]]
-        ] = None
-        self._ros_odometry: Optional[RosOdometry] = None
-        self._ros_odometry_callback: Optional[
-            callable[[RosOdometry], Awaitable[None]]
-        ] = None
-        self._ros_laser_scan: Optional[RosLaserScan] = None
-        self._ros_laser_scan_callback: Optional[
-            callable[[RosLaserScan], Awaitable[None]]
-        ] = None
-        self._front_camera_ros_camera_info: Optional[RosCameraInfo] = None
-        self._front_camera_ros_camera_info_callback: Optional[
-            callable[[RosCameraInfo], Awaitable[None]]
-        ] = None
-        self._front_camera_ros_image: Optional[RosImage] = None
-        self._front_camera_ros_image_callback: Optional[
-            callable[[RosImage], Awaitable[None]]
-        ] = None
-        self._front_camera_ros_compressed_image: Optional[
-            RosCompressedImage
-        ] = None
-        self._front_camera_ros_compressed_image_callback: Optional[
-            callable[[RosCompressedImage], Awaitable[None]]
-        ] = None
-        self._command_state: Optional[Tuple[CommandState, Command]] = None
-        self._command_state_callback: Optional[
-            callable[[CommandState, Command], Awaitable[None]]
-        ] = None
-        self._last_command_result: Optional[Tuple[Result, Command]] = None
-        self._last_command_result_callback: Optional[
-            callable[[Result, Command], Awaitable[None]]
-        ] = None
-        self._shelves: Optional[list[Shelf]] = []
-        self._shelves_callback: Optional[
-            callable[[list[Shelf]], Awaitable[None]]
-        ] = None
-        self._locations: Optional[list[Location]] = None
-        self._locations_callback: Optional[
-            callable[[list[Location]], Awaitable[None]]
-        ] = None
-        self._default_location_id: Optional[str] = None
-        self._default_location_id_callback: Optional[
-            callable[[str], Awaitable[None]]
-        ] = None
-        self._histories: Optional[list[History]] = None
-        self._histories_callback: Optional[
-            callable[[list[History]], Awaitable[None]]
-        ] = None
-        self._auto_homing_enabled: Optional[bool] = None
-        self._auto_homing_enabled_callback: Optional[
-            callable[[bool], Awaitable[None]]
-        ] = None
-        self._manual_control_enabled: Optional[bool] = None
-        self._manual_control_enabled_callback: Optional[
-            callable[[bool], Awaitable[None]]
-        ] = None
+        self.png_map: ResponseHandler[
+            pb2.GetPngMapResponse, pb2.Map
+        ] = ResponseHandler(self.stub.GetPngMap, lambda r: r.map)
 
-    def shutdown(self) -> None:
-        self._running = False
+        self.object_detection: TupleResponseHandler[
+            pb2.GetObjectDetectionResponse,
+            tuple[pb2.RosHeader, RepeatedCompositeContainer],
+            [pb2.RosHeader, RepeatedCompositeContainer],
+        ] = TupleResponseHandler(
+            self.stub.GetObjectDetection, lambda r: (r.header, r.objects)
+        )
 
-    async def _run_get_robot_serial_number(self) -> None:
-        while self._running and self._robot_serial_number_callback is not None:
-            request = build_get_request(self.get_robot_serial_number_cursor)
-            response = await self.stub.GetRobotSerialNumber(request)
-            self.get_robot_serial_number_cursor = response.metadata.cursor
+        self.ros_imu: ResponseHandler[
+            pb2.GetRosImuResponse, pb2.RosImu
+        ] = ResponseHandler(self.stub.GetRosImu, lambda r: r.imu)
 
-            self._robot_serial_number = response.robot_serial_number
-            assert self._robot_serial_number is not None
+        self.ros_odometry: ResponseHandler[
+            pb2.GetRosOdometryResponse, pb2.RosOdometry
+        ] = ResponseHandler(self.stub.GetRosOdometry, lambda r: r.odometry)
 
-            if self._robot_serial_number_callback:
-                await self._robot_serial_number_callback(
-                    self._robot_serial_number
-                )
+        self.ros_laser_scan: ResponseHandler[
+            pb2.GetRosLaserScanResponse, pb2.RosLaserScan
+        ] = ResponseHandler(self.stub.GetRosLaserScan, lambda r: r.scan)
 
-    async def _run_get_robot_version(self) -> None:
-        while self._running and self._robot_version_callback is not None:
-            request = build_get_request(self.get_robot_version_cursor)
-            response = await self.stub.GetRobotVersion(request)
-            self.get_robot_version_cursor = response.metadata.cursor
+        self.front_camera_ros_image: ResponseHandler[
+            pb2.GetFrontCameraRosImageResponse, pb2.RosImage
+        ] = ResponseHandler(self.stub.GetFrontCameraRosImage, lambda r: r.image)
 
-            self._robot_version = response.version
-            assert self._robot_version is not None
+        self.front_camera_ros_compressed_image: ResponseHandler[
+            pb2.GetFrontCameraRosCompressedImageResponse, pb2.RosCompressedImage
+        ] = ResponseHandler(
+            self.stub.GetFrontCameraRosCompressedImage, lambda r: r.image
+        )
 
-            if self._robot_version_callback:
-                await self._robot_version_callback(self._robot_version)
+        self.command_state: TupleResponseHandler[
+            pb2.GetCommandStateResponse,
+            tuple[pb2.CommandState, pb2.Command],
+            [pb2.CommandState, pb2.Command],
+        ] = TupleResponseHandler(
+            self.stub.GetCommandState, lambda r: (r.state, r.command)
+        )
 
-    async def _run_get_robot_pose(self) -> None:
-        while self._running and self._robot_pose_callback is not None:
-            request = build_get_request(self.get_robot_pose_cursor)
-            response = await self.stub.GetRobotPose(request)
-            self.get_robot_pose_cursor = response.metadata.cursor
+        self.last_command_result: TupleResponseHandler[
+            pb2.GetLastCommandResultResponse,
+            tuple[pb2.Result, pb2.Command],
+            [pb2.Result, pb2.Command],
+        ] = TupleResponseHandler(
+            self.stub.GetLastCommandResult, lambda r: (r.result, r.command)
+        )
 
-            self._robot_pose = response.robot_pose
+        self.locations: ResponseHandler[
+            pb2.GetLocationsResponse, RepeatedCompositeContainer
+        ] = ResponseHandler(self.stub.GetLocations, lambda r: r.locations)
 
-            if self._robot_pose_callback:
-                await self._robot_pose_callback(self._robot_pose)
+        self.shelves: ResponseHandler[
+            pb2.GetShelvesResponse, RepeatedCompositeContainer
+        ] = ResponseHandler(self.stub.GetShelves, lambda r: r.shelves)
 
-    async def _run_get_png_map(self) -> None:
-        while self._running and self._png_map_callback is not None:
-            request = build_get_request(self.get_png_map_cursor)
-            response = await self.stub.GetPngMap(request)
-            self.get_png_map_cursor = response.metadata.cursor
+        self.auto_homing_enabled: ResponseHandler[
+            pb2.GetAutoHomingEnabledResponse, bool
+        ] = ResponseHandler(self.stub.GetAutoHomingEnabled, lambda r: r.enabled)
 
-            self._png_map = response.png_map
+        self.manual_control_enabled: ResponseHandler[
+            pb2.GetManualControlEnabledResponse, bool
+        ] = ResponseHandler(
+            self.stub.GetManualControlEnabled, lambda r: r.enabled
+        )
 
-            if self._png_map_callback:
-                await self._png_map_callback(self._png_map)
+        self.history_list: ResponseHandler[
+            pb2.GetHistoryListResponse, RepeatedCompositeContainer
+        ] = ResponseHandler(self.stub.GetHistoryList, lambda r: r.histories)
 
-    async def _run_get_object_detection(self) -> None:
-        while self._running and self._object_detection_callback is not None:
-            request = build_get_request(self.get_object_detection_cursor)
-            response = await self.stub.GetObjectDetection(request)
-            self.get_object_detection_cursor = response.metadata.cursor
+    def set_robot_pose_callback(self, callback: CallbackType[pb2.Pose]) -> None:
+        self.robot_pose.set_callback(callback)
 
-            self._object_detection = (
-                response.header,
-                response.objects,
-            )
-
-            if self._object_detection_callback:
-                await self._object_detection_callback(
-                    self._object_detection[0], self._object_detection[1]
-                )
-
-    async def _run_get_ros_imu(self) -> None:
-        while self._running and self._ros_imu_callback is not None:
-            request = build_get_request(self.get_ros_imu_cursor)
-            response = await self.stub.GetRosImu(request)
-            self.get_ros_imu_cursor = response.metadata.cursor
-
-            self._ros_imu = response.imu
-
-            if self._ros_imu_callback:
-                await self._ros_imu_callback(self._ros_imu)
-
-    async def _run_get_ros_odometry(self) -> None:
-        while self._running and self._ros_odometry_callback is not None:
-            request = build_get_request(self.get_ros_odometry_cursor)
-            response = await self.stub.GetRosOdometry(request)
-            self.get_ros_odometry_cursor = response.metadata.cursor
-
-            self._ros_odometry = response.odometry
-
-            if self._ros_odometry_callback:
-                await self._ros_odometry_callback(self._ros_odometry)
-
-    async def _run_get_ros_laser_scan(self) -> None:
-        while self._running and self._ros_laser_scan_callback is not None:
-            request = build_get_request(self.get_ros_laser_scan_cursor)
-            response = await self.stub.GetRosLaserScan(request)
-            self.get_ros_laser_scan_cursor = response.metadata.cursor
-
-            self._ros_laser_scan = response.scan
-
-            if self._ros_laser_scan_callback:
-                await self._ros_laser_scan_callback(self._ros_laser_scan)
-
-    async def _run_get_front_camera_ros_camera_info(self) -> None:
-        while (
-            self._running
-            and self._front_camera_ros_camera_info_callback is not None
-        ):
-            request = build_get_request(
-                self.get_front_camera_ros_camera_info_cursor
-            )
-            response = await self.stub.GetFrontCameraRosCameraInfo(request)
-            self.get_front_camera_ros_camera_info_cursor = (
-                response.metadata.cursor
-            )
-
-            self._front_camera_ros_camera_info = (
-                response.front_camera_ros_camera_info
-            )
-
-            if self._front_camera_ros_camera_info_callback:
-                await self._front_camera_ros_camera_info_callback(
-                    self._front_camera_ros_camera_info
-                )
-
-    async def _run_get_front_camera_ros_image(self) -> None:
-        while (
-            self._running and self._front_camera_ros_image_callback is not None
-        ):
-            request = build_get_request(self.get_front_camera_ros_image_cursor)
-            response = await self.stub.GetFrontCameraRosImage(request)
-            self.get_front_camera_ros_image_cursor = response.metadata.cursor
-
-            self._front_camera_ros_image = response.front_camera_ros_image
-
-            if self._front_camera_ros_image_callback:
-                await self._front_camera_ros_image_callback(
-                    self._front_camera_ros_image
-                )
-
-    async def _run_get_front_camera_ros_compressed_image(self) -> None:
-        while (
-            self._running
-            and self._front_camera_ros_compressed_image_callback is not None
-        ):
-            request = build_get_request(
-                self.get_front_camera_ros_compressed_image_cursor
-            )
-            response = await self.stub.GetFrontCameraRosCompressedImage(request)
-            self.get_front_camera_ros_compressed_image_cursor = (
-                response.metadata.cursor
-            )
-
-            self._front_camera_ros_compressed_image = (
-                response.front_camera_ros_compressed_image
-            )
-
-            if self._front_camera_ros_compressed_image_callback:
-                await self._front_camera_ros_compressed_image_callback(
-                    self._front_camera_ros_compressed_image
-                )
-
-    async def _run_get_command_state(self) -> None:
-        while self._running and self._command_state_callback is not None:
-            request = build_get_request(self.get_command_state_cursor)
-            response = await self.stub.GetCommandState(request)
-            self.get_command_state_cursor = response.metadata.cursor
-
-            self._command_state = (response.command_state, response.command)
-
-            if self._command_state_callback:
-                await self._command_state_callback(*self._command_state)
-
-    async def _run_get_last_command_result(self) -> None:
-        while self._running and self._last_command_result_callback is not None:
-            request = build_get_request(self.get_last_command_result_cursor)
-            response = await self.stub.GetLastCommandResult(request)
-            self.get_last_command_result_cursor = response.metadata.cursor
-
-            self._last_command_result = (response.result, response.command)
-
-            if self._last_command_result_callback:
-                await self._last_command_result_callback(
-                    *self._last_command_result
-                )
-
-    async def _run_get_shelves(self) -> None:
-        while self._running and self._shelves_callback is not None:
-            request = build_get_request(self.get_shelves_cursor)
-            response = await self.stub.GetShelves(request)
-            self.get_shelves_cursor = response.metadata.cursor
-
-            self._shelves = response.shelves
-
-            if self._shelves_callback:
-                await self._shelves_callback(self._shelves)
-
-    async def _run_get_locations(self) -> None:
-        while self._running and self._locations_callback is not None:
-            request = build_get_request(self.get_locations_cursor)
-            response = await self.stub.GetLocations(request)
-            self.get_locations_cursor = response.metadata.cursor
-
-            self._locations = response.locations
-            self._default_location_id = response.default_location_id
-            assert self._default_location_id is not None
-
-            callback_calls = []
-            if self._locations_callback is not None:
-                callback_calls.append(self._locations_callback(self._locations))
-
-            if self._default_location_id_callback is not None:
-                callback_calls.append(
-                    self._default_location_id_callback(
-                        self._default_location_id
-                    )
-                )
-
-            await asyncio.gather(*callback_calls)
-
-    async def _run_get_histories(self) -> None:
-        while self._running and self._histories_callback is not None:
-            request = build_get_request(self.get_history_list_cursor)
-            response = await self.stub.GetHistoryList(request)
-            self.get_history_list_cursor = response.metadata.cursor
-
-            self._histories = response.histories
-
-            if self._histories_callback:
-                await self._histories_callback(self._histories)
-
-    async def _run_get_auto_homing_enabled(self) -> None:
-        while self._running and self._auto_homing_enabled_callback is not None:
-            request = build_get_request(self.get_auto_homing_enabled_cursor)
-            response = await self.stub.GetAutoHomingEnabled(request)
-            self.get_auto_homing_enabled_cursor = response.metadata.cursor
-
-            self._auto_homing_enabled = response.auto_homing_enabled
-            assert self._auto_homing_enabled is not None
-
-            if self._auto_homing_enabled_callback:
-                await self._auto_homing_enabled_callback(
-                    self._auto_homing_enabled
-                )
-
-    async def _run_get_manual_control_enabled(self) -> None:
-        while (
-            self._running and self._manual_control_enabled_callback is not None
-        ):
-            request = build_get_request(self.get_manual_control_enabled_cursor)
-            response = await self.stub.GetManualControlEnabled(request)
-            self.get_manual_control_enabled_cursor = response.metadata.cursor
-
-            self._manual_control_enabled = response.manual_control_enabled
-            assert self._manual_control_enabled is not None
-
-            if self._manual_control_enabled_callback:
-                await self._manual_control_enabled_callback(
-                    self._manual_control_enabled
-                )
-
-    def set_robot_serial_number_callback(
-        self, callback: Optional[callable[[str], Awaitable[None]]]
-    ) -> None:
-        self._robot_serial_number_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_robot_serial_number())
-
-    def set_robot_version_callback(
-        self, callback: Optional[callable[[str], Awaitable[None]]]
-    ) -> None:
-        self._robot_version_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_robot_version())
-
-    def set_robot_pose_callback(
-        self, callback: Optional[callable[[Pose], Awaitable[None]]]
-    ) -> None:
-        self._robot_pose_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_robot_pose())
-
-    def set_png_map_callback(
-        self, callback: Optional[callable[[Map], Awaitable[None]]]
-    ) -> None:
-        self._png_map_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_png_map())
+    def set_png_map_callback(self, callback: CallbackType[pb2.Map]) -> None:
+        self.png_map.set_callback(callback)
 
     def set_object_detection_callback(
         self,
-        callback: Optional[
-            callable[[RosHeader, list[ObjectDetection]], Awaitable[None]]
-        ],
+        callback: Callable[
+            [pb2.RosHeader, RepeatedCompositeContainer], Awaitable[None]
+        ]
+        | None,
     ) -> None:
-        self._object_detection_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_object_detection())
+        self.object_detection.set_tuple_callback(callback)
 
     def set_ros_imu_callback(
-        self, callback: Optional[callable[[RosImu], Awaitable[None]]]
+        self,
+        callback: CallbackType[pb2.RosImu],
     ) -> None:
-        self._ros_imu_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_ros_imu())
+        self.ros_imu.set_callback(callback)
 
     def set_ros_odometry_callback(
-        self, callback: Optional[callable[[RosOdometry], Awaitable[None]]]
+        self,
+        callback: CallbackType[pb2.RosOdometry],
     ) -> None:
-        self._ros_odometry_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_ros_odometry())
+        self.ros_odometry.set_callback(callback)
 
     def set_ros_laser_scan_callback(
-        self, callback: Optional[callable[[RosLaserScan], Awaitable[None]]]
+        self,
+        callback: CallbackType[pb2.RosLaserScan],
     ) -> None:
-        self._ros_laser_scan_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_ros_laser_scan())
-
-    def set_front_camera_ros_camera_info_callback(
-        self, callback: Optional[callable[[RosCameraInfo], Awaitable[None]]]
-    ) -> None:
-        self._front_camera_ros_camera_info_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_front_camera_ros_camera_info())
+        self.ros_laser_scan.set_callback(callback)
 
     def set_front_camera_ros_image_callback(
-        self, callback: Optional[callable[[RosImage], Awaitable[None]]]
+        self,
+        callback: CallbackType[pb2.RosImage],
     ) -> None:
-        self._front_camera_ros_image_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_front_camera_ros_image())
+        self.front_camera_ros_image.set_callback(callback)
 
     def set_front_camera_ros_compressed_image_callback(
         self,
-        callback: Optional[callable[[RosCompressedImage], Awaitable[None]]],
+        callback: CallbackType[pb2.RosCompressedImage],
     ) -> None:
-        self._front_camera_ros_compressed_image_callback = callback
-        if callback is not None:
-            asyncio.create_task(
-                self._run_get_front_camera_ros_compressed_image()
-            )
+        self.front_camera_ros_compressed_image.set_callback(callback)
 
     def set_command_state_callback(
         self,
-        callback: Optional[callable[[CommandState, Command], Awaitable[None]]],
+        callback: Callable[[pb2.CommandState, pb2.Command], Awaitable[None]]
+        | None,
     ) -> None:
-        self._command_state_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_command_state())
+        self.command_state.set_tuple_callback(callback)
+
+    def set_locations_callback(
+        self, callback: CallbackType[RepeatedCompositeContainer]
+    ) -> None:
+        self.locations.set_callback(callback)
+
+    def set_shelves_callback(
+        self, callback: CallbackType[RepeatedCompositeContainer]
+    ) -> None:
+        self.shelves.set_callback(callback)
 
     def set_last_command_result_callback(
         self,
-        callback: Optional[callable[[Result, Command], Awaitable[None]]],
+        callback: Callable[[pb2.Result, pb2.Command], Awaitable[None]] | None,
     ) -> None:
-        self._last_command_result_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_last_command_result())
-
-    def set_shelves_callback(
-        self, callback: Optional[callable[[list[Shelf]], Awaitable[None]]]
-    ) -> None:
-        self._shelves_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_shelves())
-
-    def set_locations_callback(
-        self, callback: Optional[callable[[list[Location]], Awaitable[None]]]
-    ) -> None:
-        self._locations_callback = callback
-        self._start_locations_if_necessary()
-
-    def set_default_location_id_callback(
-        self, callback: Optional[callable[[str], Awaitable[None]]]
-    ) -> None:
-        self._default_location_id_callback = callback
-        self._start_locations_if_necessary()
-
-    def set_history_list_callback(
-        self, callback: Optional[callable[[list[History]], Awaitable[None]]]
-    ) -> None:
-        self._histories_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_histories())
+        self.last_command_result.set_tuple_callback(callback)
 
     def set_auto_homing_enabled_callback(
-        self, callback: Optional[callable[[bool], Awaitable[None]]]
+        self, callback: CallbackType[bool]
     ) -> None:
-        self._auto_homing_enabled_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_auto_homing_enabled())
+        self.auto_homing_enabled.set_callback(callback)
 
     def set_manual_control_enabled_callback(
-        self, callback: Optional[callable[[bool], Awaitable[None]]]
+        self, callback: CallbackType[bool]
     ) -> None:
-        self._manual_control_enabled_callback = callback
-        if callback is not None:
-            asyncio.create_task(self._run_get_manual_control_enabled())
+        self.manual_control_enabled.set_callback(callback)
 
-    def _start_locations_if_necessary(self) -> None:
-        if (
-            self._locations_callback is not None
-            or self._default_location_id_callback is not None
-        ):
-            asyncio.create_task(self._run_get_locations())
+    def set_history_list_callback(
+        self, callback: CallbackType[RepeatedCompositeContainer]
+    ) -> None:
+        self.history_list.set_callback(callback)

--- a/python/kachaka_api/aio/__init__.py
+++ b/python/kachaka_api/aio/__init__.py
@@ -13,15 +13,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Generic,
-    ParamSpec,
-    Protocol,
-    TypeVar,
-)
+from typing import Awaitable, Callable, Generic, ParamSpec, Protocol, TypeVar
 
 from google._upb._message import RepeatedCompositeContainer
 
@@ -39,7 +31,6 @@ class HasMetadata(Protocol):
 
 T = TypeVar("T", bound=HasMetadata)
 U = TypeVar("U")
-V = TypeVar("V", bound=tuple[Any, ...])
 P = ParamSpec("P")
 CallbackType = Callable[[U], Awaitable[None]] | None
 
@@ -76,11 +67,11 @@ class TupleResponseHandler(ResponseHandler[T, U], Generic[T, U, P]):
     def set_tuple_callback(
         self, callback: Callable[P, Awaitable[None]] | None
     ) -> None:
-        if self.callback is not None and callback is not None:
-            raise RuntimeError("Callback is already set")
         if callback is None:
             self.callback = None
             return
+        if self.callback is not None:
+            raise RuntimeError("Callback is already set")
 
         def extract_tuple_and_run(args: U) -> Awaitable[None]:
             assert isinstance(args, tuple)


### PR DESCRIPTION
kachaka_api/aio/__init__.py をmypyかけるのついでにコード重複周りを リファクタリグしました。
genericsにしておくことでset_callbackに相当するような新しいを機能XXXX追加するときに、ResponseHandlerに追加するだけ済むようになります。e.g. `client.robot_pose.XXXX`

下記のcallbackをは提供する必要もなさそうだったので消しました
- serial_number
- robot_id
- front_camera_ros_camera_info

また、locationに依存するcallbackが複数あると複雑になる & callbackあまり必要になさそうなので、
default_location_idのcallbackも削除しました。

参考: https://docs.python.org/ja/3.10/library/typing.html 