### PR TITLE
mypy to utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,15 @@ Repository = "https://github.com/pf-robotics/kachaka-api"
 [tool.setuptools]
 package-dir = {"" = "python"}
 
+[tool.mypy]
+files = [
+    "python/kachaka_api/base.py",
+    "python/kachaka_api/aio/",
+    "python/kachaka_api/util/",
+    "python/demos/sample_llm_speak.py",
+]
+ignore_missing_imports = true
+
 [tool.pysen]
 version = "0.10.5"
 
@@ -18,7 +27,7 @@ version = "0.10.5"
 enable_black = true
 enable_flake8 = true
 enable_isort = true
-enable_mypy = true
+enable_mypy = false
 line_length = 80
 py_version = "py310"
 
@@ -26,13 +35,6 @@ py_version = "py310"
 excludes = [
   ".flexci/env.sh",
   "python/kachaka_api/generated",
-]
-
-[[tool.pysen.lint.mypy_targets]]
-paths = [
-    "python/kachaka_api/base.py",
-    "python/kachaka_api/aio/",
-    "python/demos/sample_llm_speak.py",
 ]
 
 [tool.pysen.plugin.clang_format]

--- a/python/demos/sample_llm_speak.py
+++ b/python/demos/sample_llm_speak.py
@@ -13,8 +13,9 @@ import openai
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + "/../")
 
-from kachaka_api import CommandTextFormatter, pb2  # noqa: E402
+from kachaka_api import pb2  # noqa: E402
 from kachaka_api.aio import KachakaApiClient  # noqa: E402
+from kachaka_api.util.command import CommandTextFormatter  # noqa: E402
 
 
 @dataclass
@@ -59,7 +60,7 @@ def ask_chatgpt(system: str, prompt: str) -> str:
             {"role": "system", "content": system},
             {"role": "user", "content": prompt},
         ],
-    )  # type: ignore
+    )
     return result["choices"][0]["message"]["content"]  # type: ignore
 
 

--- a/python/kachaka_api/__init__.py
+++ b/python/kachaka_api/__init__.py
@@ -11,10 +11,11 @@
 # limitations under the License.
 
 from . import aio  # noqa: F401
-from .base import KachakaApiClientBase  # noqa: F401
-from .command_util import CommandTextFormatter  # noqa: F401
+from .base import KachakaApiClientBase
 from .generated import kachaka_api_pb2 as pb2  # noqa: F401
-from .layout_util import ShelfLocationResolver  # noqa: F401
+from .util import command as command_util  # noqa: F401
+from .util import geometry as geometry_util  # noqa: F401
+from .util import layout as layout_util  # noqa: F401
 
 
 class KachakaApiClient(KachakaApiClientBase):

--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -15,7 +15,7 @@ from google._upb._message import RepeatedCompositeContainer
 
 from ..generated import kachaka_api_pb2 as pb2
 from ..generated.kachaka_api_pb2_grpc import KachakaApiStub
-from ..layout_util import ShelfLocationResolver
+from ..util.layout import ShelfLocationResolver
 
 
 class KachakaApiClientBase:

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -18,7 +18,7 @@ from google._upb._message import RepeatedCompositeContainer
 
 from .generated import kachaka_api_pb2 as pb2
 from .generated.kachaka_api_pb2_grpc import KachakaApiStub
-from .layout_util import ShelfLocationResolver
+from .util.layout import ShelfLocationResolver
 
 
 class KachakaApiClientBase:

--- a/python/kachaka_api/util/command.py
+++ b/python/kachaka_api/util/command.py
@@ -10,8 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .generated import kachaka_api_pb2
-from .layout_util import ShelfLocationResolver
+from ..generated import kachaka_api_pb2
+from .layout import ShelfLocationResolver
 
 
 class CommandTextFormatter:

--- a/python/kachaka_api/util/geometry.py
+++ b/python/kachaka_api/util/geometry.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import numpy as np
 
-from .generated.kachaka_api_pb2 import Map, Pose, Quaternion
+from ..generated.kachaka_api_pb2 import Map, Pose, Quaternion
 
 
 def calculate_yaw_from_quaternion(q: Quaternion) -> float:

--- a/python/kachaka_api/util/layout.py
+++ b/python/kachaka_api/util/layout.py
@@ -12,13 +12,15 @@
 
 from typing import Tuple
 
-from .generated import kachaka_api_pb2 as pb2
+from ..generated import kachaka_api_pb2 as pb2
 
 
 class ShelfLocationResolver:
-    def __init__(self, shelves=None, locations=None) -> None:
-        self.shelves: list[pb2.Shelf] = shelves or []
-        self.locations: list[pb2.Location] = locations or []
+    def __init__(
+        self, shelves: list[pb2.Shelf] = [], locations: list[pb2.Location] = []
+    ) -> None:
+        self.shelves = shelves
+        self.locations = locations
 
     def set_shelves(self, shelves: list[pb2.Shelf]) -> None:
         self.shelves = shelves

--- a/tools/lint/local_run.sh
+++ b/tools/lint/local_run.sh
@@ -25,6 +25,7 @@ mapfile -t ipynb_files < <(git ls-files | grep ipynb)
 if [[ "$FORMAT" -eq 1 ]]; then
     ./tools/update_kachaka_api_base.py
     pysen run format lint
+    mypy
     # TODO(nozaki) Use pysen plugins
     nbqa black "${ipynb_files[@]}"
     nbqa isort "${ipynb_files[@]}"
@@ -39,6 +40,7 @@ else
         exit 1
     }
     pysen run lint
+    mypy
     # TODO(nozaki) Use pysen plugins
     nbqa black "${ipynb_files[@]}" --diff --check
     nbqa isort "${ipynb_files[@]}" --diff --check-only


### PR DESCRIPTION
kachaka_api.xxx_utilに対するmypyを有効化します。
既存のディレクトリ構成だとgenerated避けをするのに不便だったので、xxx_util.pyをutil/xxx.pyに移動しました。
__init__.pyで xxx_utilとしてimportしているのでこれまでのコードもそのまま動きます。
また、なぜかpysen経由の呼び出しだとmypyがnumpyまわりを一部うまく解決してくれないので、mypyはpysen経由ではなくそのまま呼ぶことにしました。