### PR TITLE
Add install_libraries.ipynb

### DIFF
--- a/python/demos/install_libraries.ipynb
+++ b/python/demos/install_libraries.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "da6044b1-aa88-485d-8208-69a2dbbcbaf9",
+   "metadata": {},
+   "source": [
+    "# 依存ライブラリのインストール\n",
+    "\n",
+    "demoのプログラムが依存しているライブラリを一括でインストールします"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9da010bc-3388-4621-b45e-5f52e50f4c4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U pip\n",
+    "!pip install -r requirements.txt"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/demos/requirements.txt
+++ b/python/demos/requirements.txt
@@ -9,6 +9,7 @@ frozenlist==1.4.0
 grpcio-tools==1.56.2
 grpcio==1.56.2
 idna==3.4
+ipympl==0.9.3
 ipywidgets==8.1.0
 matplotlib==3.7.2
 multidict==6.0.4

--- a/python/demos/requirements.txt
+++ b/python/demos/requirements.txt
@@ -1,3 +1,4 @@
+Pillow==10.0.0
 aiohttp==3.8.5
 aiosignal==1.3.1
 async-timeout==4.0.2
@@ -5,15 +6,20 @@ attrs==23.1.0
 certifi==2023.7.22
 charset-normalizer==3.2.0
 frozenlist==1.4.0
-grpcio==1.56.2
 grpcio-tools==1.56.2
+grpcio==1.56.2
 idna==3.4
+ipywidgets==8.1.0
+matplotlib==3.7.2
 multidict==6.0.4
 openai==0.27.8
+opencv-python-headless==4.8.0.76
 paho-mqtt==1.6.1
+plotly==5.16.1
 protobuf==4.23.4
 requests==2.31.0
 schedule==1.2.0
 tqdm==4.65.0
 urllib3==2.0.4
 yarl==1.9.2
+-e ../../


### PR DESCRIPTION
demoが依存するライブラリ、およびkachaka-apiを一括でpip installするnotebookを追加します。
実行してplaygroundのtotalディスクの使用量は491MBでした

https://github.com/nozaki-pfr/kachaka-api/blob/775554dd1491473421d29a4d612bf6a87dd461cf/python/demos/install_libraries.ipynb