### PR TITLE
Use kachaka client in get_front_camera sample

### DIFF
--- a/python/demos/get_front_camera.ipynb
+++ b/python/demos/get_front_camera.ipynb
@@ -88,13 +88,13 @@
    "outputs": [],
    "source": [
     "image = client.get_front_camera_ros_image()\n",
-    "image = np.ndarray(\n",
+    "np_image = np.ndarray(\n",
     "    shape=(image.height, image.width, 3),\n",
     "    dtype=np.uint8,\n",
     "    buffer=image.data,\n",
     ")\n",
     "# 圧縮画像として表示\n",
-    "_, ret = cv2.imencode(\".jpg\", image[..., ::-1])\n",
+    "_, ret = cv2.imencode(\".jpg\", np_image[..., ::-1])\n",
     "display(Image(data=ret, format=\"jpeg\"))"
    ]
   }

--- a/python/demos/get_front_camera.ipynb
+++ b/python/demos/get_front_camera.ipynb
@@ -5,7 +5,7 @@
    "id": "4bcba01b-7d02-4d53-84b1-e5d71ae5b8f5",
    "metadata": {},
    "source": [
-    "# カメラ画像(raw)の取得\n",
+    "# カメラ画像の取得\n",
     "\n",
     "opencvのインストールを行うコマンドが入っています。一度実行した後はこの処理はスキップ可能です。初回インストール後にkernelの再起動が必要です。"
    ]
@@ -38,11 +38,9 @@
    "outputs": [],
    "source": [
     "import cv2\n",
-    "import grpc\n",
-    "import kachaka_api_pb2\n",
+    "import kachaka_api\n",
     "import numpy as np\n",
-    "from IPython.display import Image, display\n",
-    "from kachaka_api_pb2_grpc import KachakaApiStub"
+    "from IPython.display import Image, display"
    ]
   },
   {
@@ -52,7 +50,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stub = KachakaApiStub(grpc.aio.insecure_channel(kachaka_api_server))"
+    "client = kachaka_api.KachakaApiClient()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25850926-7e13-4b7f-81c2-ab982220da3b",
+   "metadata": {},
+   "source": [
+    "# 圧縮画像の取得"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6180794e-d907-49f4-8906-650c10f32e15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = client.get_front_camera_ros_compressed_image()\n",
+    "display(Image(data=image.data, format=\"jpeg\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60040386-520e-4bc2-82a4-d69e36b33c29",
+   "metadata": {},
+   "source": [
+    "# 生画像の取得"
    ]
   },
   {
@@ -62,12 +87,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp = await stub.GetFrontCameraRosImage(kachaka_api_pb2.GetRequest())\n",
+    "image = client.get_front_camera_ros_image()\n",
     "image = np.ndarray(\n",
-    "    shape=(resp.image.height, resp.image.width, 3),\n",
+    "    shape=(image.height, image.width, 3),\n",
     "    dtype=np.uint8,\n",
-    "    buffer=resp.image.data,\n",
+    "    buffer=image.data,\n",
     ")\n",
+    "# 圧縮画像として表示\n",
     "_, ret = cv2.imencode(\".jpg\", image[..., ::-1])\n",
     "display(Image(data=ret, format=\"jpeg\"))"
    ]

--- a/python/demos/get_front_camera.ipynb
+++ b/python/demos/get_front_camera.ipynb
@@ -68,8 +68,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "image = client.get_front_camera_ros_compressed_image()\n",
-    "display(Image(data=image.data, format=\"jpeg\"))"
+    "compressed_image = client.get_front_camera_ros_compressed_image()\n",
+    "display(Image(data=compressed_image.data, format=\"jpeg\"))"
    ]
   },
   {


### PR DESCRIPTION
フロントカメラから画像を1枚取得するサンプルを、KachakaApiClientを使うものに差し替えます。
また生画像1枚を取得する例のみだったのを、圧縮画像と生画像を1枚ずつ取得する例にしておきます。
(連続画像取得のサンプルはaioを使ったものなので、これで過不足なくしておきたいです)