### PR TITLE
remove unnecessary input argument in KachakaApiClient initialization

### DIFF
--- a/python/demos/get_front_camera_continuous.ipynb
+++ b/python/demos/get_front_camera_continuous.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client = kachaka_api.aio.KachakaApiClient(kachaka_api_server)"
+    "client = kachaka_api.aio.KachakaApiClient()"
    ]
   },
   {

--- a/python/demos/get_object_detection.ipynb
+++ b/python/demos/get_object_detection.ipynb
@@ -47,7 +47,7 @@
     "from IPython.display import Image, clear_output\n",
     "from PIL import Image\n",
     "\n",
-    "client = kachaka_api.aio.KachakaApiClient(kachaka_api_server)\n",
+    "client = kachaka_api.aio.KachakaApiClient()\n",
     "\n",
     "LABEL_NAME = [\"?\", \"person\", \"shelf\", \"charger\", \"door\"]\n",
     "LABEL_COLOR = [\"pink\", \"green\", \"blue\", \"cyan\", \"red\"]\n",

--- a/python/demos/url_kachaka_api.ipynb
+++ b/python/demos/url_kachaka_api.ipynb
@@ -72,7 +72,7 @@
     "from google.protobuf.json_format import MessageToDict\n",
     "\n",
     "app = FastAPI()\n",
-    "kachaka_client = kachaka_api.aio.KachakaApiClient(kachaka_api_server)\n",
+    "kachaka_client = kachaka_api.aio.KachakaApiClient()\n",
     "\n",
     "\n",
     "@app.on_event(\"startup\")\n",


### PR DESCRIPTION
KachakaApiClientを使う際はデフォルトで"100.94.1.1:26400"が指定されているので、必要ない引数指定を辞めます。
https://github.com/pf-robotics/kachaka-api/blob/main/python/kachaka_api/aio/base.py#L22

(setup_demo_envからkachaka_api_serverも消したいですが、 demos内のサンプルを全てKachakaApiClient利用に移行させてからですね)
