### PR TITLE
Allow set_velocity to be specified in m/s and rad/s

### DIFF
--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -17,6 +17,9 @@ from ..generated import kachaka_api_pb2 as pb2
 from ..generated.kachaka_api_pb2_grpc import KachakaApiStub
 from ..util.layout import ShelfLocationResolver
 
+MAX_LINEAR_VELOCITY = 0.3
+MAX_ANGULAR_VELOCITY = 1.57
+
 
 class KachakaApiClientBase:
     def __init__(self, target: str = "100.94.1.1:26400"):
@@ -384,7 +387,10 @@ class KachakaApiClientBase:
     async def set_robot_velocity(
         self, linear: float, angular: float
     ) -> pb2.Result:
-        request = pb2.SetRobotVelocityRequest(linear=linear, angular=angular)
+        request = pb2.SetRobotVelocityRequest(
+            linear=linear / MAX_LINEAR_VELOCITY,
+            angular=angular / MAX_ANGULAR_VELOCITY,
+        )
         response: pb2.SetRobotVelocityResponse = (
             await self.stub.SetRobotVelocity(request)
         )

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -20,6 +20,9 @@ from .generated import kachaka_api_pb2 as pb2
 from .generated.kachaka_api_pb2_grpc import KachakaApiStub
 from .util.layout import ShelfLocationResolver
 
+MAX_LINEAR_VELOCITY = 0.3
+MAX_ANGULAR_VELOCITY = 1.57
+
 
 class KachakaApiClientBase:
     def __init__(self, target: str = "100.94.1.1:26400"):
@@ -373,7 +376,10 @@ class KachakaApiClientBase:
         return response.enabled
 
     def set_robot_velocity(self, linear: float, angular: float) -> pb2.Result:
-        request = pb2.SetRobotVelocityRequest(linear=linear, angular=angular)
+        request = pb2.SetRobotVelocityRequest(
+            linear=linear / MAX_LINEAR_VELOCITY,
+            angular=angular / MAX_ANGULAR_VELOCITY,
+        )
         response: pb2.SetRobotVelocityResponse = self.stub.SetRobotVelocity(
             request
         )


### PR DESCRIPTION
指令値が-1~1に正規化される仕様でした。
ROS2同様にset_robot_velocityもm/s, rad/sで指定できるようにします