### PR TITLE
Call set_manual_control automatically when set_robot_velocity called

### DIFF
--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -384,7 +384,7 @@ class KachakaApiClientBase:
         )
         return response.enabled
 
-    async def set_robot_velocity(
+    async def _impl_set_robot_velocity(
         self, linear: float, angular: float
     ) -> pb2.Result:
         request = pb2.SetRobotVelocityRequest(
@@ -395,6 +395,19 @@ class KachakaApiClientBase:
             await self.stub.SetRobotVelocity(request)
         )
         return response.result
+
+    async def set_robot_velocity(
+        self, linear: float, angular: float
+    ) -> pb2.Result:
+        result = await self._impl_set_robot_velocity(linear, angular)
+        if result.success:
+            return result
+        await self.set_manual_control_enabled(True)
+        return await self._impl_set_robot_velocity(linear, angular)
+
+    async def set_robot_stop(self):
+        await self.set_robot_velocity(0, 0)
+        await self.set_manual_control_enabled(False)
 
     async def get_history_list(
         self,

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -375,7 +375,9 @@ class KachakaApiClientBase:
         )
         return response.enabled
 
-    def set_robot_velocity(self, linear: float, angular: float) -> pb2.Result:
+    def _impl_set_robot_velocity(
+        self, linear: float, angular: float
+    ) -> pb2.Result:
         request = pb2.SetRobotVelocityRequest(
             linear=linear / MAX_LINEAR_VELOCITY,
             angular=angular / MAX_ANGULAR_VELOCITY,
@@ -384,6 +386,17 @@ class KachakaApiClientBase:
             request
         )
         return response.result
+
+    def set_robot_velocity(self, linear: float, angular: float) -> pb2.Result:
+        result = self._impl_set_robot_velocity(linear, angular)
+        if result.success:
+            return result
+        self.set_manual_control_enabled(True)
+        return self._impl_set_robot_velocity(linear, angular)
+
+    def set_robot_stop(self):
+        self.set_robot_velocity(0, 0)
+        self.set_manual_control_enabled(False)
 
     def get_history_list(
         self,


### PR DESCRIPTION
manual_control_enable ROS2では、set_robot_velocityが失敗したら投げているとのこと。なるほどとなったのでkachaka_apiでも同じようにします。
disableも自然にできると良さそう & set_robot_velocity はロボットが速度を一定時間保有してしまう都合上明示的に止めたほうがよいので、set_robot_stopも合わせて足しました