### PR TITLE
Add /kachaka/front_camera/image_raw/camera_info

### DIFF
--- a/ros2/kachaka_description/config/kachaka.rviz
+++ b/ros2/kachaka_description/config/kachaka.rviz
@@ -287,7 +287,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Best Effort
-        Value: /kachaka/front_camera/image_raw
+        Value: /kachaka/front_camera/image_raw/compressed
       Value: true
   Enabled: true
   Global Options:


### PR DESCRIPTION
これまでは `/kachaka/front_camera/camera_info` しかなかったので、CompressedImageをRViz2などで利用するには以下のようにremapする必要がありました。

```
rviz2 --ros-args --remap /kachaka/front_camera/image_raw/camera_info:=/kachaka/front_camera/camera_info
```

このPRでは`/kachaka/front_camera/image_raw/camera_info` を追加し、remapの必要をなくします。
`kachaka.rviz`も修正して、画像更新が早くなったことを確認済み。