### PR TITLE
Refactor CameraComponent by separating CameraBridge and FrontCameraComponent

### DIFF
--- a/ros2/kachaka_grpc_ros2_bridge/CMakeLists.txt
+++ b/ros2/kachaka_grpc_ros2_bridge/CMakeLists.txt
@@ -31,8 +31,8 @@ ament_auto_add_library(
   gen-src/kachaka-api.grpc.pb.cc
   gen-src/kachaka-api.pb.cc
   src/component/auto_homing_component.cpp
-  src/component/camera_component.cpp
   src/component/dynamic_tf_component.cpp
+  src/component/front_camera_component.cpp
   src/component/goal_pose_component.cpp
   src/component/imu_component.cpp
   src/component/kachaka_command_component.cpp
@@ -68,9 +68,9 @@ rclcpp_components_register_node(
 rclcpp_components_register_node(
   ${PROJECT_NAME}
   PLUGIN
-  "kachaka::grpc_ros2_bridge::CameraComponent"
+  "kachaka::grpc_ros2_bridge::FrontCameraComponent"
   EXECUTABLE
-  camera)
+  front_camera)
 
 rclcpp_components_register_node(
   ${PROJECT_NAME}

--- a/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
+++ b/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
@@ -25,7 +25,7 @@
                  value="false" />
     </composable_node>
     <composable_node pkg="kachaka_grpc_ros2_bridge"
-                     plugin="kachaka::grpc_ros2_bridge::CameraComponent"
+                     plugin="kachaka::grpc_ros2_bridge::FrontCameraComponent"
                      name="front_camera"
                      namespace="kachaka">
       <param name="server_uri"

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
@@ -1,0 +1,60 @@
+//  Copyright 2023 Preferred Robotics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include <grpcpp/grpcpp.h>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+
+#include "../camera_bridge.hpp"
+#include "kachaka-api.grpc.pb.h"
+
+namespace kachaka::grpc_ros2_bridge {
+
+class FrontCameraComponent : public rclcpp::Node {
+ public:
+  explicit FrontCameraComponent(const rclcpp::NodeOptions& options)
+      : Node("front_camera", options) {
+    stub_ = GetSharedStub(declare_parameter("server_uri", ""));
+    using namespace std::placeholders;
+    front_camera_bridge_ = std::make_unique<
+        CameraBridge<kachaka_api::GetFrontCameraRosCameraInfoResponse,
+                     kachaka_api::GetFrontCameraRosImageResponse,
+                     kachaka_api::GetFrontCameraRosCompressedImageResponse>>(
+        stub_, this,
+        std::bind(&kachaka_api::KachakaApi::Stub::GetFrontCameraRosCameraInfo,
+                  *stub_, _1, _2, _3),
+        std::bind(&kachaka_api::KachakaApi::Stub::GetFrontCameraRosImage,
+                  *stub_, _1, _2, _3),
+        std::bind(
+            &kachaka_api::KachakaApi::Stub::GetFrontCameraRosCompressedImage,
+            *stub_, _1, _2, _3));
+  }
+
+  ~FrontCameraComponent() = default;
+
+  FrontCameraComponent(const FrontCameraComponent&) = delete;
+  FrontCameraComponent& operator=(const FrontCameraComponent&) = delete;
+
+ private:
+  std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
+  std::unique_ptr<
+      CameraBridge<kachaka_api::GetFrontCameraRosCameraInfoResponse,
+                   kachaka_api::GetFrontCameraRosImageResponse,
+                   kachaka_api::GetFrontCameraRosCompressedImageResponse>>
+      front_camera_bridge_;
+};
+
+}  // namespace kachaka::grpc_ros2_bridge
+
+RCLCPP_COMPONENTS_REGISTER_NODE(kachaka::grpc_ros2_bridge::FrontCameraComponent)


### PR DESCRIPTION
CameraComponentをリファクタリングし、CameraBridgeとそれを呼ぶFrontCameraComponentに分割しました。将来的に後ろカメラコンポーネントなどを追加しやすくするためです。動作に変化はありません。動作確認済み。