### PR TITLE
Set timeout for some APIs useful for checking endpoint liveness and connectivity

### DIFF
--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -29,17 +29,17 @@ class KachakaApiClientBase:
         self.stub = KachakaApiStub(grpc.insecure_channel(target))
         self.resolver = ShelfLocationResolver()
 
-    def get_robot_serial_number(self) -> str:
+    def get_robot_serial_number(self, *, timeout: float | None = None) -> str:
         request = pb2.GetRequest()
         response: pb2.GetRobotSerialNumberResponse = (
-            self.stub.GetRobotSerialNumber(request)
+            self.stub.GetRobotSerialNumber(request, timeout=timeout)
         )
         return response.serial_number
 
-    def get_robot_version(self) -> str:
+    def get_robot_version(self, *, timeout: float | None = None) -> str:
         request = pb2.GetRequest()
         response: pb2.GetRobotVersionResponse = self.stub.GetRobotVersion(
-            request
+            request, timeout=timeout
         )
         return response.version
 


### PR DESCRIPTION
A practical applications using kachaka API would need to check whether the target Kachaka host (API endpoint) is alive or not.
Although there is no API exactly for that purpose right now, I suppose one can simply call `get_robot_serial_number` or `get_robot_version` and see if they succeed.
One problem I have had is that when the API endpoint is not reachable the Python wrapper interface blocks for 20 seconds (MacOS host case) which makes my app frozen, but we usually won't have to wait that long since the API expects the client to be in the same local network.
In this PR I'd like to propose the `timeout` option for those API wrappers functions which is directly passed to gRPC core timeout, so that I can simply let these API wait only for ~0.5s to check API endpoint liveness.
For other API functions I think setting timeout is irrelevant, so I only focused on `get_robot_serial_number` or `get_robot_version` in this PR.