### PR TITLE
kachaka_follow depends common_interfaces instead

### DIFF
--- a/ros2/demos/kachaka_follow/package.xml
+++ b/ros2/demos/kachaka_follow/package.xml
@@ -9,7 +9,7 @@
   <author email="support@kachaka.life">Kachaka Customer Support</author>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>geoemetry_msgs</exec_depend>
+  <exec_depend>common_interfaces</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>kachaka_interfaces</exec_depend>
 


### PR DESCRIPTION
ROS 2 Humble以降で`geometry_msgs`は単体パッケージでは配られていないので、それを内包する`common_interface`に依存するようにしました。

```
$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
kachaka_follow: Cannot locate rosdep definition for [geoemetry_msgs]
```