### PR TITLE
specify numpy version in requirements.txt

### DIFF
--- a/python/demos/requirements.txt
+++ b/python/demos/requirements.txt
@@ -14,6 +14,7 @@ ipympl==0.9.3
 ipywidgets==8.1.0
 matplotlib==3.7.2
 multidict==6.0.4
+numpy==1.26.4
 onnxruntime==1.17.0
 openai==0.27.8
 opencv-python-headless==4.8.0.76


### PR DESCRIPTION
未対応のnumpy 2.0がインストールされてしまうのを防ぐ為、numpyのバージョンを固定しておきます。
https://github.com/pf-robotics/kachaka-api/discussions/94