### PR TITLE
Updated kachaka-nav.rviz

### DIFF
--- a/ros2/demos/kachaka_nav2_bringup/rviz/kachaka-nav.rviz
+++ b/ros2/demos/kachaka_nav2_bringup/rviz/kachaka-nav.rviz
@@ -14,7 +14,6 @@ Panels:
     Name: Selection
   - Class: rviz_common/Tool Properties
     Expanded:
-      - /2D Goal Pose1
       - /Publish Point1
     Name: Tool Properties
     Splitter Ratio: 0.5886790156364441
@@ -28,6 +27,8 @@ Panels:
     Name: Time
     SyncMode: 0
     SyncSource: LaserScan
+  - Class: nav2_rviz_plugins/Navigation 2
+    Name: Navigation 2
 Visualization Manager:
   Class: ""
   Displays:
@@ -119,7 +120,7 @@ Visualization Manager:
     - Alpha: 0.699999988079071
       Class: rviz_default_plugins/Map
       Color Scheme: map
-      Draw Behind: false
+      Draw Behind: true
       Enabled: true
       Name: Map
       Topic:
@@ -137,7 +138,7 @@ Visualization Manager:
         Value: /kachaka/mapping/map_updates
       Use Timestamp: false
       Value: true
-    - Alpha: 0.10000000149011612
+    - Alpha: 0.30000001192092896
       Class: rviz_default_plugins/Map
       Color Scheme: costmap
       Draw Behind: false
@@ -487,7 +488,7 @@ Visualization Manager:
       Axis: Z
       Channel Name: intensity
       Class: rviz_default_plugins/LaserScan
-      Color: 255; 255; 255
+      Color: 0; 255; 0
       Color Transformer: FlatColor
       Decay Time: 0
       Enabled: true
@@ -499,9 +500,9 @@ Visualization Manager:
       Name: LaserScan
       Position Transformer: XYZ
       Selectable: true
-      Size (Pixels): 3
+      Size (Pixels): 5
       Size (m): 0.019999999552965164
-      Style: Flat Squares
+      Style: Points
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -579,6 +580,18 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /plan
       Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /waypoints
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -603,13 +616,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /initialpose
-    - Class: rviz_default_plugins/SetGoal
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /goal_pose2
     - Class: rviz_default_plugins/PublishPoint
       Single click: true
       Topic:
@@ -618,6 +624,7 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /clicked_point
+    - Class: nav2_rviz_plugins/GoalTool
   Transformation:
     Current:
       Class: rviz_default_plugins/TF
@@ -632,9 +639,9 @@ Visualization Manager:
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: 1.854304552078247
-        Y: -10.70637321472168
-        Z: -0.1753927320241928
+        X: -0.7087763547897339
+        Y: 1.0705846548080444
+        Z: -0.18718110024929047
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false


### PR DESCRIPTION
`kachaka_nav2_bringup/rviz/kachaka-nav.rviz`の更新をしました。変更点は配下の通りです。

- 占有格子地図（mapトピック）の描画設定をDraw Behind=Trueにする
  - 現状のコストマップ、占有格子地図の描画順だと視認性が悪いため
- `nav2_rviz_plugins/Navigation`パネル追加
  - navigation2のステータスを可視化するため
- ゴール指定を`nav2_rviz_plugins/GoalTool`に変更
  - RViz2パネルからWaypoint指定するため
- scanの可視化方法変更
  - 白色、Flat Squaresだと視認性が悪いため
- 視点変更
  - デフォルトだと地図の原点から離れた場所に視点があるため
- Waypoint可視化
  - Waypoint指定時に可視化するため