### PR TITLE
specify correct version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kachaka-api"
-version = "1.1.0"
+version = "3.4.7"
 authors = [{name="Preferred Robotics inc."}]
 dependencies = ["grpcio", "numpy", "protobuf"]
 readme = "README.md"


### PR DESCRIPTION
PyPIでの公開の準備として、pyproject.tomlのバージョンがずっと変わっていないままだったので、バージョン番号を合わせます。(今後はリリースのたびに適切に更新する)