### PR TITLE
[ROS2] Feature to allow multiple Kachaka robots within one same ROS_DOMAIN_ID

### DIFF
--- a/ros2/kachaka_description/launch/robot_description.launch.xml
+++ b/ros2/kachaka_description/launch/robot_description.launch.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="namespace"
+       default="kachaka" />
+  <arg name="frame_prefix"
+       default="/" />
   <node pkg="robot_state_publisher"
         exec="robot_state_publisher"
         name="robot_state_publisher"
-        namespace="kachaka_description">
+        namespace="$(var namespace)">
     <param name="robot_description"
            value="$(command 'cat $(find-pkg-share kachaka_description)/robot/kachaka.urdf')" />
+    <param name="frame_prefix"
+           value="$(var frame_prefix)" />
   </node>
 </launch>

--- a/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
+++ b/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="namespace"
+       default="kachaka" />
+  <arg name="frame_prefix"
+       default="/" />
   <arg name="server_uri"
        default="localhost:2021" />
   <node_container pkg="rclcpp_components"
                   exec="component_container_mt"
                   name="grpc_ros2_bridge_container"
-                  namespace="kachaka">
+                  namespace="$(var namespace)">
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::AutoHomingComponent"
                      name="auto_homing"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -18,7 +22,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::BackCameraComponent"
                      name="back_camera"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -27,7 +33,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::DiagnosticsComponent"
                      name="diagnostics"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -36,7 +42,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::KachakaCommandComponent"
                      name="kachaka_command"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -45,7 +51,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::FrontCameraComponent"
                      name="front_camera"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -54,16 +62,18 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::GoalPoseComponent"
                      name="goal_pose"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <remap from="~/goal_pose"
-             to="/goal_pose" />
+             to="goal_pose" />
       <extra_arg name="use_intra_process_comms"
                  value="false" />
     </composable_node>
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::ImuComponent"
                      name="imu"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -72,7 +82,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::LayoutComponent"
                      name="layout"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -81,7 +91,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::LidarComponent"
                      name="lidar"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -90,7 +102,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::ManualControlComponent"
                      name="manual_control"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -99,7 +111,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::MappingComponent"
                      name="mapping"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -108,7 +122,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::RobotInfoComponent"
                      name="robot_info"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -118,7 +132,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::ObjectDetectionComponent"
                      name="object_detection"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -127,7 +141,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::OdometryComponent"
                      name="odometry"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -136,7 +152,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::WheelOdometryComponent"
                      name="wheel_odometry"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -145,7 +163,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::TofCameraComponent"
                      name="tof_camera"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -154,7 +174,7 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::TorchComponent"
                      name="torch"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -163,7 +183,9 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::StaticTfComponent"
                      name="static_tf"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
@@ -172,12 +194,19 @@
     <composable_node pkg="kachaka_grpc_ros2_bridge"
                      plugin="kachaka::grpc_ros2_bridge::DynamicTfComponent"
                      name="dynamic_tf"
-                     namespace="kachaka">
+                     namespace="$(var namespace)">
+      <param name="frame_prefix"
+             value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
       <extra_arg name="use_intra_process_comms"
                  value="false" />
     </composable_node>
   </node_container>
-  <include file="$(find-pkg-share kachaka_description)/launch/robot_description.launch.xml" />
+  <include file="$(find-pkg-share kachaka_description)/launch/robot_description.launch.xml" >
+    <arg name="namespace"
+         value="$(var namespace)" />
+    <arg name="frame_prefix"
+         value="$(var frame_prefix)" />
+  </include>
 </launch>

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/back_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/back_camera_component.cpp
@@ -25,6 +25,8 @@ class BackCameraComponent : public rclcpp::Node {
  public:
   explicit BackCameraComponent(const rclcpp::NodeOptions& options)
       : Node("back_camera", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
     using namespace std::placeholders;
     back_camera_bridge_ = std::make_unique<
@@ -47,6 +49,7 @@ class BackCameraComponent : public rclcpp::Node {
   BackCameraComponent& operator=(const BackCameraComponent&) = delete;
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<
       CameraBridge<kachaka_api::GetBackCameraRosCameraInfoResponse,

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/back_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/back_camera_component.cpp
@@ -33,7 +33,7 @@ class BackCameraComponent : public rclcpp::Node {
         CameraBridge<kachaka_api::GetBackCameraRosCameraInfoResponse,
                      kachaka_api::GetBackCameraRosImageResponse,
                      kachaka_api::GetBackCameraRosCompressedImageResponse>>(
-        stub_, this, false,
+        frame_prefix_, stub_, this, false,
         std::bind(&kachaka_api::KachakaApi::Stub::GetBackCameraRosCameraInfo,
                   *stub_, _1, _2, _3),
         std::bind(&kachaka_api::KachakaApi::Stub::GetBackCameraRosImage, *stub_,

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/diagnostics_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/diagnostics_component.cpp
@@ -33,6 +33,8 @@ class DiagnosticsComponent : public rclcpp::Node {
  public:
   explicit DiagnosticsComponent(const rclcpp::NodeOptions& options)
       : Node("diagnostics", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
 
     rclcpp::SystemDefaultsQoS qos;
@@ -60,7 +62,7 @@ class DiagnosticsComponent : public rclcpp::Node {
         [&, this](const kachaka_api::GetErrorResponse& grpc_msg,
                   diagnostic_msgs::msg::DiagnosticArray* ros2_msg) {
           ros2_msg->header.stamp = this->now();
-          ros2_msg->header.frame_id = "";
+          ros2_msg->header.frame_id = this->frame_prefix_;
 
           const auto& error_codes = grpc_msg.error_codes();
           for (auto& ec : error_codes) {
@@ -135,6 +137,7 @@ class DiagnosticsComponent : public rclcpp::Node {
   const std::string ERROR_TYPE_FATAL = "Fatal";
   const std::string ERROR_TYPE_CALL_FOR_SUPPORT = "CallForSupport";
   json robot_error_dictionary_;
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<Ros2TopicBridge<kachaka_api::GetErrorResponse,
                                   diagnostic_msgs::msg::DiagnosticArray>>

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/dynamic_tf_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/dynamic_tf_component.cpp
@@ -32,11 +32,13 @@ class DynamicTfComponent : public rclcpp::Node {
       : Node("dynamic_tf", options) {
     RCLCPP_INFO(this->get_logger(), "start dynamic tf");
 
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
 
     RCLCPP_INFO(this->get_logger(), "get stub");
 
-    dynamic_tf_client_ = std::make_unique<TfStreamClient>(stub_, this);
+    dynamic_tf_client_ = std::make_unique<TfStreamClient>(frame_prefix_, stub_, this);
 
     dynamic_tf_client_->ReadStream();
     RCLCPP_INFO(this->get_logger(), "start read dynamic tf");
@@ -47,6 +49,7 @@ class DynamicTfComponent : public rclcpp::Node {
   DynamicTfComponent& operator=(const DynamicTfComponent&) = delete;
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<TfStreamClient> dynamic_tf_client_;
 };

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
@@ -25,6 +25,8 @@ class FrontCameraComponent : public rclcpp::Node {
  public:
   explicit FrontCameraComponent(const rclcpp::NodeOptions& options)
       : Node("front_camera", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
     using namespace std::placeholders;
     front_camera_bridge_ = std::make_unique<
@@ -47,6 +49,7 @@ class FrontCameraComponent : public rclcpp::Node {
   FrontCameraComponent& operator=(const FrontCameraComponent&) = delete;
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<
       CameraBridge<kachaka_api::GetFrontCameraRosCameraInfoResponse,

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/front_camera_component.cpp
@@ -33,7 +33,7 @@ class FrontCameraComponent : public rclcpp::Node {
         CameraBridge<kachaka_api::GetFrontCameraRosCameraInfoResponse,
                      kachaka_api::GetFrontCameraRosImageResponse,
                      kachaka_api::GetFrontCameraRosCompressedImageResponse>>(
-        stub_, this, false,
+        frame_prefix_, stub_, this, false,
         std::bind(&kachaka_api::KachakaApi::Stub::GetFrontCameraRosCameraInfo,
                   *stub_, _1, _2, _3),
         std::bind(&kachaka_api::KachakaApi::Stub::GetFrontCameraRosImage,

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/mapping_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/mapping_component.cpp
@@ -30,6 +30,8 @@ class MappingComponent : public rclcpp::Node {
  public:
   explicit MappingComponent(const rclcpp::NodeOptions& options)
       : Node("map", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
 
     rclcpp::QoS qos(rclcpp::KeepLast{1});
@@ -45,7 +47,7 @@ class MappingComponent : public rclcpp::Node {
     map_bridge_->SetConverter(
         [this](const kachaka_api::GetPngMapResponse& grpc_msg,
                nav_msgs::msg::OccupancyGrid* ros2_msg) {
-          ros2_msg->header.frame_id = kOriginFrameId;
+          ros2_msg->header.frame_id = this->frame_prefix_ + std::string(kOriginFrameId);
           ros2_msg->header.stamp = get_clock()->now();
           if (grpc_msg.map().data().empty()) {
             return false;
@@ -109,6 +111,7 @@ class MappingComponent : public rclcpp::Node {
     }
   }
 
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<Ros2TopicBridge<kachaka_api::GetPngMapResponse,
                                   nav_msgs::msg::OccupancyGrid>>

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/static_tf_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/static_tf_component.cpp
@@ -27,15 +27,16 @@
 namespace {
 bool ConvertGrpcTfToRosTf(
     const kachaka_api::GetStaticTransformResponse& grpc_msg,
-    tf2_msgs::msg::TFMessage* msg) {
+    tf2_msgs::msg::TFMessage* msg,
+    std::string frame_prefix = "") {
   msg->transforms.clear();
   msg->transforms.reserve(grpc_msg.transforms_size());
   for (const auto& transform_grpc : grpc_msg.transforms()) {
     geometry_msgs::msg::TransformStamped transform_ros;
     kachaka::grpc_ros2_bridge::converter::ConvertGrpcHeaderToRos2Header(
-        transform_grpc.header(), &(transform_ros.header));
+        transform_grpc.header(), &(transform_ros.header), frame_prefix);
 
-    transform_ros.child_frame_id = transform_grpc.child_frame_id();
+    transform_ros.child_frame_id = frame_prefix + transform_grpc.child_frame_id();
     transform_ros.transform.translation.x = transform_grpc.translation().x();
     transform_ros.transform.translation.y = transform_grpc.translation().y();
     transform_ros.transform.translation.z = transform_grpc.translation().z();
@@ -57,6 +58,8 @@ class StaticTfComponent : public rclcpp::Node {
  public:
   explicit StaticTfComponent(const rclcpp::NodeOptions& options)
       : Node("static_tf", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
 
     using namespace std::placeholders;
@@ -66,7 +69,12 @@ class StaticTfComponent : public rclcpp::Node {
         std::bind(&kachaka_api::KachakaApi::Stub::GetStaticTransform, *stub_,
                   _1, _2, _3),
         "/tf_static", tf2_ros::StaticBroadcasterQoS());
-    static_tf_bridge_->SetConverter(ConvertGrpcTfToRosTf);
+    static_tf_bridge_->SetConverter(
+        [this](const kachaka_api::GetStaticTransformResponse& grpc_msg,
+               tf2_msgs::msg::TFMessage* ros2_msg) {
+          ConvertGrpcTfToRosTf(grpc_msg, ros2_msg, frame_prefix_);
+          return true;
+        });
     static_tf_bridge_->StartAsync();
   }
   ~StaticTfComponent() override { static_tf_bridge_->StopAsync(); }
@@ -75,6 +83,7 @@ class StaticTfComponent : public rclcpp::Node {
   StaticTfComponent& operator=(const StaticTfComponent&) = delete;
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<Ros2TopicBridge<kachaka_api::GetStaticTransformResponse,
                                   tf2_msgs::msg::TFMessage>>

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/tof_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/tof_camera_component.cpp
@@ -25,6 +25,8 @@ class TofCameraComponent : public rclcpp::Node {
  public:
   explicit TofCameraComponent(const rclcpp::NodeOptions& options)
       : Node("tof_camera", options) {
+    this->declare_parameter("frame_prefix", "");
+    frame_prefix_ = this->get_parameter("frame_prefix").as_string();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
     using namespace std::placeholders;
     tof_camera_bridge_ = std::make_unique<
@@ -47,6 +49,7 @@ class TofCameraComponent : public rclcpp::Node {
   TofCameraComponent& operator=(const TofCameraComponent&) = delete;
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<
       CameraBridge<kachaka_api::GetTofCameraRosCameraInfoResponse,

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/tof_camera_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/tof_camera_component.cpp
@@ -33,7 +33,7 @@ class TofCameraComponent : public rclcpp::Node {
         CameraBridge<kachaka_api::GetTofCameraRosCameraInfoResponse,
                      kachaka_api::GetTofCameraRosImageResponse,
                      kachaka_api::GetTofCameraRosCompressedImageResponse>>(
-        stub_, this, true,
+        frame_prefix_, stub_, this, true,
         std::bind(&kachaka_api::KachakaApi::Stub::GetTofCameraRosCameraInfo,
                   *stub_, _1, _2, _3),
         std::bind(&kachaka_api::KachakaApi::Stub::GetTofCameraRosImage, *stub_,

--- a/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.cpp
@@ -21,7 +21,7 @@ namespace kachaka::grpc_ros2_bridge::converter {
 
 void ConvertGrpcHeaderToRos2Header(const kachaka_api::RosHeader& grpc_header,
                                    std_msgs::msg::Header* ros2_header,
-                                   std::string frame_prefix) {
+                                   const std::string& frame_prefix) {
   ros2_header->stamp = rclcpp::Time(grpc_header.stamp_nsec());
   ros2_header->frame_id = frame_prefix + grpc_header.frame_id();
 }

--- a/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.cpp
@@ -20,9 +20,10 @@
 namespace kachaka::grpc_ros2_bridge::converter {
 
 void ConvertGrpcHeaderToRos2Header(const kachaka_api::RosHeader& grpc_header,
-                                   std_msgs::msg::Header* ros2_header) {
+                                   std_msgs::msg::Header* ros2_header,
+                                   std::string frame_prefix) {
   ros2_header->stamp = rclcpp::Time(grpc_header.stamp_nsec());
-  ros2_header->frame_id = grpc_header.frame_id();
+  ros2_header->frame_id = frame_prefix + grpc_header.frame_id();
 }
 
 }  // namespace kachaka::grpc_ros2_bridge::converter

--- a/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.hpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.hpp
@@ -20,6 +20,6 @@ namespace kachaka::grpc_ros2_bridge::converter {
 
 void ConvertGrpcHeaderToRos2Header(const kachaka_api::RosHeader& grpc_header,
                                    std_msgs::msg::Header* ros2_header,
-                                   std::string frame_prefix = "");
+                                   const std::string& frame_prefix = "");
 
 }  // namespace kachaka::grpc_ros2_bridge::converter

--- a/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.hpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/converter/ros_header.hpp
@@ -19,6 +19,7 @@
 namespace kachaka::grpc_ros2_bridge::converter {
 
 void ConvertGrpcHeaderToRos2Header(const kachaka_api::RosHeader& grpc_header,
-                                   std_msgs::msg::Header* ros2_header);
+                                   std_msgs::msg::Header* ros2_header,
+                                   std::string frame_prefix = "");
 
 }  // namespace kachaka::grpc_ros2_bridge::converter

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
@@ -51,7 +51,7 @@ namespace kachaka::grpc_ros2_bridge {
 
 TfStreamClient::TfStreamClient(
     std::string frame_prefix, std::shared_ptr<kachaka_api::KachakaApi::Stub> stub, rclcpp::Node* node)
-    : frame_prefix_(frame_prefix),
+    : frame_prefix_(std::move(frame_prefix)),
       stub_(stub),
       node_(node),
       publisher_(node->create_publisher<tf2_msgs::msg::TFMessage>(

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
@@ -22,15 +22,16 @@
 namespace {
 bool ConvertGrpcTfToRosTf(
     const kachaka_api::GetDynamicTransformResponse& grpc_msg,
-    tf2_msgs::msg::TFMessage* msg) {
+    tf2_msgs::msg::TFMessage* msg,
+    const std::string& frame_prefix = "") {
   msg->transforms.clear();
   msg->transforms.reserve(grpc_msg.transforms_size());
   for (const auto& transform_grpc : grpc_msg.transforms()) {
     geometry_msgs::msg::TransformStamped transform_ros;
     kachaka::grpc_ros2_bridge::converter::ConvertGrpcHeaderToRos2Header(
-        transform_grpc.header(), &(transform_ros.header));
+        transform_grpc.header(), &(transform_ros.header), frame_prefix);
 
-    transform_ros.child_frame_id = transform_grpc.child_frame_id();
+    transform_ros.child_frame_id = frame_prefix + transform_grpc.child_frame_id();
     transform_ros.transform.translation.x = transform_grpc.translation().x();
     transform_ros.transform.translation.y = transform_grpc.translation().y();
     transform_ros.transform.translation.z = transform_grpc.translation().z();
@@ -49,8 +50,9 @@ bool ConvertGrpcTfToRosTf(
 namespace kachaka::grpc_ros2_bridge {
 
 TfStreamClient::TfStreamClient(
-    std::shared_ptr<kachaka_api::KachakaApi::Stub> stub, rclcpp::Node* node)
-    : stub_(stub),
+    std::string frame_prefix, std::shared_ptr<kachaka_api::KachakaApi::Stub> stub, rclcpp::Node* node)
+    : frame_prefix_(frame_prefix),
+      stub_(stub),
       node_(node),
       publisher_(node->create_publisher<tf2_msgs::msg::TFMessage>(
           "/tf", tf2_ros::DynamicBroadcasterQoS(5))) {}
@@ -66,7 +68,7 @@ void TfStreamClient::ReadStream() {
 
   while (reader->Read(&response)) {
     tf2_msgs::msg::TFMessage msg;
-    ConvertGrpcTfToRosTf(response, &msg);
+    ConvertGrpcTfToRosTf(response, &msg, frame_prefix_);
     publisher_->publish(msg);
   }
   RCLCPP_INFO(node_->get_logger(), "dynamic tf server is stopped.");

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.hpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.hpp
@@ -21,11 +21,13 @@ namespace kachaka::grpc_ros2_bridge {
 
 class TfStreamClient {
  public:
-  TfStreamClient(std::shared_ptr<kachaka_api::KachakaApi::Stub> stub,
+  TfStreamClient(std::string frame_prefix,
+                 std::shared_ptr<kachaka_api::KachakaApi::Stub> stub,
                  rclcpp::Node* node);
   void ReadStream();
 
  private:
+  std::string frame_prefix_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   rclcpp::Node* node_;
   typename rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr publisher_;

--- a/tools/ros2_bridge/docker-compose.yaml
+++ b/tools/ros2_bridge/docker-compose.yaml
@@ -2,11 +2,13 @@ version: "2.4"
 
 services:
   ros2_bridge:
-    image: "asia-northeast1-docker.pkg.dev/kachaka-api/docker/kachaka-grpc-ros2-bridge:${TAG}"
+    image: "kachaka-api:latest"
     network_mode: "host"
     ipc: "host"
     pid: "host"
     environment:
+      - NAMESPACE
+      - FRAME_PREFIX
       - API_GRPC_BRIDGE_SERVER_URI
       - ROS_DOMAIN_ID
       - ROS_LOCALHOST_ONLY
@@ -16,7 +18,7 @@ services:
       - GROUP_ID
     user: "${USER_ID}:${GROUP_ID}"
     command: >
-      ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml server_uri:=${API_GRPC_BRIDGE_SERVER_URI}
+      ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml server_uri:=${API_GRPC_BRIDGE_SERVER_URI} namespace:=${NAMESPACE} frame_prefix:=${FRAME_PREFIX}
   kachaka_follow:
     image: "asia-northeast1-docker.pkg.dev/kachaka-api/docker/kachaka-grpc-ros2-bridge:${TAG}"
     network_mode: "host"

--- a/tools/ros2_bridge/docker-compose.yaml
+++ b/tools/ros2_bridge/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.4"
 
 services:
   ros2_bridge:
-    image: "kachaka-api:latest"
+    image: "asia-northeast1-docker.pkg.dev/kachaka-api/docker/kachaka-grpc-ros2-bridge:${TAG}"
     network_mode: "host"
     ipc: "host"
     pid: "host"

--- a/tools/ros2_bridge/start_bridge.sh
+++ b/tools/ros2_bridge/start_bridge.sh
@@ -6,13 +6,21 @@ DOCKER_COMPOSE_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DOCKER_COMPOSE_DIR}"
 
 usage() {
-    echo "Usage: $0 KACHAKA_IP_ADRESS [Option]"
+    echo "Usage: $0 KACHAKA_IP_ADRESS [KACHAKA_NAME] [Option]"
     echo "  -d    daemonize"
     exit 1
 }
 
 if [[ $# -lt 1 ]]; then
     usage
+fi
+
+if [[ $# -lt 2 ]]; then
+    NAMESPACE="kachaka"
+    FRAME_PREFIX='/'
+else
+    NAMESPACE=$2
+    FRAME_PREFIX=$2"/"
 fi
 
 USER_ID="$(id -u)"
@@ -25,7 +33,7 @@ export GROUP_ID
 KACHAKA_IP=$1
 
 if command -v docker-compose; then
-    API_GRPC_BRIDGE_SERVER_URI="${KACHAKA_IP}:${GRPC_PORT}" docker-compose up "${@:2}" ros2_bridge 
+    API_GRPC_BRIDGE_SERVER_URI="${KACHAKA_IP}:${GRPC_PORT}" NAMESPACE="${NAMESPACE}" FRAME_PREFIX="${FRAME_PREFIX}" docker-compose up "${@:4}" ros2_bridge 
 else
-    API_GRPC_BRIDGE_SERVER_URI="${KACHAKA_IP}:${GRPC_PORT}" docker compose up "${@:2}" ros2_bridge
+    API_GRPC_BRIDGE_SERVER_URI="${KACHAKA_IP}:${GRPC_PORT}" NAMESPACE="${NAMESPACE}" FRAME_PREFIX="${FRAME_PREFIX}" docker compose up "${@:4}" ros2_bridge
 fi


### PR DESCRIPTION
このPRでは, `kachaka_grpc_ros2_bridge` パッケージにおいて, `tf` フレーム名にプレフィックスと`namespace`を設定できる機能を追加しました．この変更により, Issue https://github.com/pf-robotics/kachaka-api/issues/136 に書かれたように同一の`ROS_DOMAIN_ID`でもマルチロボット環境での名前空間管理が可能となります．

### 主な変更点:  
1. 対象となるメッセージの `header.frame_id` および `child_frame_id` に, 指定されたフレームプレフィックスを付加するようコードを更新．
2. ランチパラメータ（`frame_prefix`や`namespace`）を追加し, ユーザーが指定できるように対応．  
3. 互換性を確保するために，プレフィックスが指定されない場合, 従来の挙動を維持．  

### テスト:  
- 単一および複数ロボットのセットアップで動作を検証し, 指定されたプレフィックスが正しく適用されることを確認しました．
```bash
$ ./start_bridge.sh KACHAKA_IP_ADRESS KACHAKA_NAME
# 例: ./start_bridge.sh 192.168.XX.YY kachaka_1
```

| `kachaka_1` | `kachaka_2` |
| --- | --- |
| ![k1](https://github.com/user-attachments/assets/e18a96db-ece7-4c08-998f-41886bb3b310) | ![k2](https://github.com/user-attachments/assets/686f6d2c-6e95-4d3d-979f-ee443e0f3cdb) |

- プレフィックスパラメータを指定せずにブリッジを起動し, 従来の挙動が維持されることを確認しました．  
```bash
$ ./start_bridge.sh KACHAKA_IP_ADRESS 
# 例: ./start_bridge.sh 192.168.XX.YY
```

| 通常 |
| --- |
| ![k](https://github.com/user-attachments/assets/76344c9e-4391-4852-a82c-67f9cdcdbf03) |

ご意見や追加の修正点がありましたらお知らせください．  
フィードバックをお待ちしております！  