### PR TITLE
[ROS 2] switch include path of cv_bridge for ROS 2 jazzy

### DIFF
--- a/ros2/kachaka_grpc_ros2_bridge/CMakeLists.txt
+++ b/ros2/kachaka_grpc_ros2_bridge/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.5)
 
 project(kachaka_grpc_ros2_bridge)
 
+# workaround for conditional include for each ROS distribution
+if($ENV{ROS_DISTRO} STREQUAL "jazzy")
+  add_compile_definitions(ROS_DISTRO_JAZZY)
+endif()
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/ros2/kachaka_grpc_ros2_bridge/src/camera_bridge.hpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/camera_bridge.hpp
@@ -16,7 +16,12 @@
 #include <memory>
 #include <utility>
 
+#if defined(ROS_DISTRO_JAZZY)  // Jazzy
+#include <cv_bridge/cv_bridge.hpp>
+#else  // Humble (default)
 #include <cv_bridge/cv_bridge.h>
+#endif
+
 #include <grpcpp/grpcpp.h>
 #include <opencv2/opencv.hpp>
 #include <rclcpp/rclcpp.hpp>


### PR DESCRIPTION
https://github.com/ros-perception/vision_opencv/pull/448

cv_bridgeのincludeパスが、JazzyからROS 2の規格に合わせて cv_bridge.h -> cv_bridge.hpp にリネームされており、ビルドが通らない状況になっていました。

一応いま標準はHumbleなので、ROS_DISTROがJazzyのときにコンパイル時定数を足して、includeをスイッチするようにします。

手元のJazzy環境でビルドできるのを確認しました。