### PR TITLE
[ROS] fix docker-compose.yaml path in doc

### DIFF
--- a/docs/ROS2.md
+++ b/docs/ROS2.md
@@ -123,6 +123,6 @@ rviz2 -d kachaka.rviz
 docker buildx build -t kachaka-api --target kachaka-grpc-ros2-bridge -f Dockerfile.ros2 . --build-arg BASE_ARCH=x86_64 --load
 ```
 
-* [tools/ros2_bridge/docker-compose.yaml](tools/ros2_bridge/docker-compose.yaml)に対して以下の変更を行います。
+* [tools/ros2_bridge/docker-compose.yaml](../tools/ros2_bridge/docker-compose.yaml)に対して以下の変更を行います。
     * 変更前：`image: "asia-northeast1-docker.pkg.dev/kachaka-api/docker/kachaka-grpc-ros2-bridge:${TAG}"`
     * 変更後：`image: kachaka-api:latest`


### PR DESCRIPTION
This pull request includes a small change to the `docs/ROS2.md` file. The change corrects the relative path to the `docker-compose.yaml` file to ensure it is correctly referenced.