### PR TITLE
python kachaka_api library: support lock and proceed in python sdk

### DIFF
--- a/docs/kachaka_api_client.ipynb
+++ b/docs/kachaka_api_client.ipynb
@@ -118,7 +118,7 @@
    "id": "0fe78765-735f-4c2f-90e9-4178382383f7",
    "metadata": {},
    "source": [
-    "### コマンドの実行"
+    "### 目的地・家具の情報の取得"
    ]
   },
   {
@@ -197,6 +197,14 @@
    "outputs": [],
    "source": [
     "client.get_moving_shelf_id()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "555ce1f9-502c-44c4-8f18-9eb7bf3d32fe",
+   "metadata": {},
+   "source": [
+    "### コマンドの実行"
    ]
   },
   {
@@ -473,6 +481,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c9bb4cf-456e-4bf2-9f12-568c48f1956f",
+   "metadata": {},
+   "source": [
+    "### コマンドの実行状態と管理"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84405186-9cd4-4b59-b97a-b0f3d2e9b410",
    "metadata": {},
    "source": [
@@ -560,6 +576,46 @@
    "outputs": [],
    "source": [
     "client.get_history_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09995176-7f46-475b-ba17-82bc84c16de4",
+   "metadata": {},
+   "source": [
+    "#### 待機状態とその解除\n",
+    "\n",
+    "lock()を実行すると、カチャカを何もしない状態のままその場に留まらせることができます。\n",
+    "pythonのプログラムでsleepするのと違って、カチャカは「待機」というコマンドを実行している状態になります。後に続いてcancel_all=Falseでコマンドを実行すると、待機状態が解除されてから次のコマンドに進みます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "664bf4c8-c92e-456e-abbe-f3471dee030c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.lock(30.0)\n",
+    "client.speak(\"30秒が経ちました\", cancel_all=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "688f396f-657a-45c8-9b65-4f7b215ad59c",
+   "metadata": {},
+   "source": [
+    "proceed()を実行すると、待機状態が終了します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5feeeb1-4621-4f2e-9b44-924a7dbfb610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.proceed()"
    ]
   },
   {
@@ -1125,7 +1181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/docs/kachaka_api_client.ipynb
+++ b/docs/kachaka_api_client.ipynb
@@ -597,7 +597,7 @@
    "outputs": [],
    "source": [
     "client.lock(30.0)\n",
-    "client.speak(\"30秒が経ちました\", cancel_all=False)"
+    "client.speak(\"待機状態が解除されました\", cancel_all=False)"
    ]
   },
   {
@@ -605,7 +605,7 @@
    "id": "688f396f-657a-45c8-9b65-4f7b215ad59c",
    "metadata": {},
    "source": [
-    "proceed()を実行すると、待機状態が終了します。"
+    "時間が経過するか、proceed()の実行により、待機状態が終了します。"
    ]
   },
   {

--- a/docs/kachaka_api_client_async.ipynb
+++ b/docs/kachaka_api_client_async.ipynb
@@ -118,7 +118,7 @@
    "id": "0fe78765-735f-4c2f-90e9-4178382383f7",
    "metadata": {},
    "source": [
-    "### コマンドの実行"
+    "### 家具・目的地の情報の取得"
    ]
   },
   {
@@ -197,6 +197,14 @@
    "outputs": [],
    "source": [
     "await client.get_moving_shelf_id()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c3175d1-230e-4fe1-83be-8e7253b22d2d",
+   "metadata": {},
+   "source": [
+    "### コマンドの実行"
    ]
   },
   {
@@ -473,6 +481,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aaab7df8-2cd7-4ae5-9ee9-f5294d11fcdc",
+   "metadata": {},
+   "source": [
+    "### コマンドの実行状態と管理"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84405186-9cd4-4b59-b97a-b0f3d2e9b410",
    "metadata": {},
    "source": [
@@ -560,6 +576,46 @@
    "outputs": [],
    "source": [
     "await client.get_history_list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6bbccc8-49e5-4177-82ba-973cfaee2f82",
+   "metadata": {},
+   "source": [
+    "#### 待機状態とその解除\n",
+    "\n",
+    "lock()を実行すると、カチャカを何もしない状態のままその場に留まらせることができます。\n",
+    "pythonのプログラムでsleepするのと違って、カチャカは「待機」というコマンドを実行している状態になります。後に続いてcancel_all=Falseでコマンドを実行すると、待機状態が解除されてから次のコマンドに進みます。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b799cacb-d9c2-43af-a8bb-49c8ddb86305",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await client.lock(30.0)\n",
+    "await client.speak(\"30秒が経ちました\", cancel_all=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dfe9f702-9929-42a0-8796-94b9b90e9bc5",
+   "metadata": {},
+   "source": [
+    "proceed()を実行すると、待機状態が終了します。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f01f2f3-e85b-4944-a337-68110be37461",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await client.proceed()"
    ]
   },
   {
@@ -1159,7 +1215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/docs/kachaka_api_client_async.ipynb
+++ b/docs/kachaka_api_client_async.ipynb
@@ -597,7 +597,7 @@
    "outputs": [],
    "source": [
     "await client.lock(30.0)\n",
-    "await client.speak(\"30秒が経ちました\", cancel_all=False)"
+    "await client.speak(\"待機状態が解除されました\", cancel_all=False)"
    ]
   },
   {
@@ -605,7 +605,7 @@
    "id": "dfe9f702-9929-42a0-8796-94b9b90e9bc5",
    "metadata": {},
    "source": [
-    "proceed()を実行すると、待機状態が終了します。"
+    "時間が経過するか、proceed()の実行により、待機状態が終了します。"
    ]
   },
   {

--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -408,6 +408,25 @@ class KachakaApiClientBase:
             title=title,
         )
 
+    async def lock(
+        self,
+        duration_sec: float,
+        *,
+        wait_for_completion: bool = True,
+        cancel_all: bool = True,
+        tts_on_success: str = "",
+        title: str = "",
+    ) -> pb2.Result:
+        return await self.start_command(
+            pb2.Command(
+                lock_command=pb2.LockCommand(duration_sec=duration_sec)
+            ),
+            wait_for_completion=wait_for_completion,
+            cancel_all=cancel_all,
+            tts_on_success=tts_on_success,
+            title=title,
+        )
+
     async def move_forward(
         self,
         distance_meter: float,
@@ -524,6 +543,11 @@ class KachakaApiClientBase:
             await self.stub.GetLastCommandResult(request)
         )
         return (response.result, response.command)
+
+    async def proceed(self) -> pb2.Result:
+        request = pb2.EmptyRequest()
+        response: pb2.ProceedResponse = await self.stub.Proceed(request)
+        return response.result
 
     async def get_locations(
         self,

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -403,6 +403,25 @@ class KachakaApiClientBase:
             title=title,
         )
 
+    def lock(
+        self,
+        duration_sec: float,
+        *,
+        wait_for_completion: bool = True,
+        cancel_all: bool = True,
+        tts_on_success: str = "",
+        title: str = "",
+    ) -> pb2.Result:
+        return self.start_command(
+            pb2.Command(
+                lock_command=pb2.LockCommand(duration_sec=duration_sec)
+            ),
+            wait_for_completion=wait_for_completion,
+            cancel_all=cancel_all,
+            tts_on_success=tts_on_success,
+            title=title,
+        )
+
     def move_forward(
         self,
         distance_meter: float,
@@ -517,6 +536,11 @@ class KachakaApiClientBase:
             self.stub.GetLastCommandResult(request)
         )
         return (response.result, response.command)
+
+    def proceed(self) -> pb2.Result:
+        request = pb2.EmptyRequest()
+        response: pb2.ProceedResponse = self.stub.Proceed(request)
+        return response.result
 
     def get_locations(
         self,


### PR DESCRIPTION
PythonのカチャカAPIライブラリで、LockとProceedがサポートされていなかったのでサポートするようにします。