### PR TITLE
Bump pre-release version to v3.10.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kachaka-api"
-version = "3.9.5"
+version = "3.10.6"
 authors = [{name="Preferred Robotics inc."}]
 dependencies = [
     "grpcio==1.66.1",


### PR DESCRIPTION
pre-release ブランチを 3.10.6 に上げます。

pre-release は既に今現在の最新の main をマージ済みです。