### PR TITLE
fixed logic to lookup id and name of shelves and locations

### DIFF
--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -289,7 +289,7 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        shelf_id = self.resolver.get_shelf_id_by_name(shelf_name_or_id)
+        shelf_id = self.resolver.resolve_shelf_id_or_name(shelf_name_or_id)
         return await self.start_command(
             pb2.Command(
                 return_shelf_command=pb2.ReturnShelfCommand(
@@ -327,7 +327,9 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        location_id = self.resolver.get_location_id_by_name(location_name_or_id)
+        location_id = self.resolver.resolve_location_id_or_name(
+            location_name_or_id
+        )
         return await self.start_command(
             pb2.Command(
                 move_to_location_command=pb2.MoveToLocationCommand(

--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -263,8 +263,10 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        shelf_id = self.resolver.get_shelf_id_by_name(shelf_name_or_id)
-        location_id = self.resolver.get_location_id_by_name(location_name_or_id)
+        shelf_id = self.resolver.resolve_shelf_id_or_name(shelf_name_or_id)
+        location_id = self.resolver.resolve_location_id_or_name(
+            location_name_or_id
+        )
         return await self.start_command(
             pb2.Command(
                 move_shelf_command=pb2.MoveShelfCommand(

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -258,8 +258,10 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        shelf_id = self.resolver.get_shelf_id_by_name(shelf_name_or_id)
-        location_id = self.resolver.get_location_id_by_name(location_name_or_id)
+        shelf_id = self.resolver.resolve_shelf_id_or_name(shelf_name_or_id)
+        location_id = self.resolver.resolve_location_id_or_name(
+            location_name_or_id
+        )
         return self.start_command(
             pb2.Command(
                 move_shelf_command=pb2.MoveShelfCommand(

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -284,7 +284,7 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        shelf_id = self.resolver.get_shelf_id_by_name(shelf_name_or_id)
+        shelf_id = self.resolver.resolve_shelf_id_or_name(shelf_name_or_id)
         return self.start_command(
             pb2.Command(
                 return_shelf_command=pb2.ReturnShelfCommand(
@@ -322,7 +322,9 @@ class KachakaApiClientBase:
         tts_on_success: str = "",
         title: str = "",
     ) -> pb2.Result:
-        location_id = self.resolver.get_location_id_by_name(location_name_or_id)
+        location_id = self.resolver.resolve_location_id_or_name(
+            location_name_or_id
+        )
         return self.start_command(
             pb2.Command(
                 move_to_location_command=pb2.MoveToLocationCommand(

--- a/python/kachaka_api/util/layout.py
+++ b/python/kachaka_api/util/layout.py
@@ -65,21 +65,23 @@ class ShelfLocationResolver:
     def resolve_location_id_or_name(
         self, location_id_or_name: str
     ) -> str | None:
-        if location_id_or_name in self.locations:
-            return location_id_or_name
-        else:
-            location_id = self.get_location_id_by_name(location_id_or_name)
-            if location_id == location_id_or_name:
-                return None
-            else:
-                return location_id
+        location_id_with_name = None
+        for location in self.locations:
+            if location.id == location_id_or_name:
+                return location.id
+
+            if location.name == location_id_or_name:
+                location_id_with_name = location.id
+
+        return location_id_with_name
 
     def resolve_shelf_id_or_name(self, shelf_id_or_name: str) -> str | None:
-        if shelf_id_or_name in self.shelves:
-            return shelf_id_or_name
-        else:
-            shelf_id = self.get_shelf_id_by_name(shelf_id_or_name)
-            if shelf_id == shelf_id_or_name:
-                return None
-            else:
-                return shelf_id
+        shelf_id_with_name = None
+        for shelf in self.shelves:
+            if shelf.id == shelf_id_or_name:
+                return shelf.id
+
+            if shelf.name == shelf_id_or_name:
+                shelf_id_with_name = shelf.id
+
+        return shelf_id_with_name

--- a/python/kachaka_api/util/layout.py
+++ b/python/kachaka_api/util/layout.py
@@ -61,3 +61,25 @@ class ShelfLocationResolver:
                 return location.id
         print(f"Failed to get location id of {location_name}")
         return location_name
+
+    def resolve_location_id_or_name(
+        self, location_id_or_name: str
+    ) -> str | None:
+        if location_id_or_name in self.locations:
+            return location_id_or_name
+        else:
+            location_id = self.get_location_id_by_name(location_id_or_name)
+            if location_id == location_id_or_name:
+                return None
+            else:
+                return location_id
+
+    def resolve_shelf_id_or_name(self, shelf_id_or_name: str) -> str | None:
+        if shelf_id_or_name in self.shelves:
+            return shelf_id_or_name
+        else:
+            shelf_id = self.get_shelf_id_by_name(shelf_id_or_name)
+            if shelf_id == shelf_id_or_name:
+                return None
+            else:
+                return shelf_id


### PR DESCRIPTION
pythonのkachaka_apiライブラリで、ID指定で棚や目的地を引数に与えたときに、

> Failed to get shelf id of S01

のようにエラーメッセージが出るようになっていました。ID指定か名前指定かに拘らず、必ず名前のルックアップを行う実装になっていたためです。

まずはIDとして扱い、IDとして存在しなければ名前として扱う、というフローに変更して、このエラー文章が出ることがないようにします。
本当は色々直したいところなのですが、一旦破壊的変更がないように修正します。