### PR TITLE
[After Merge #200] Update pyproject version for 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kachaka-api"
-version = "3.11.11"
+version = "3.12.3"
 authors = [{name="Preferred Robotics inc."}]
 dependencies = [
     "grpcio==1.66.1",


### PR DESCRIPTION
pyproject.tomlのバージョン情報を3.12へ更新します。
#200 がマージされてからマージします。