### PR TITLE
Fixed ros2/demos/kachaka_follow

### DIFF
--- a/ros2/demos/kachaka_follow/README.md
+++ b/ros2/demos/kachaka_follow/README.md
@@ -1,15 +1,15 @@
 # Follow Example
 
-# Overview
+## Overview
 
 * This is an example that uses LIDAR to move towards the nearest object. It includes instructions on how to use `cmd_vel` and `LaserScan`.
 
-# Building
+## Building
 
-*Copy the necessary folders to workspace and build the project.
+* Copy the necessary folders to workspace and build the project.
 
 ```
-mkidr -p ~/ros2_ws/src
+mkdir -p ~/ros2_ws/src
 cd ~/ros2_ws/src
 cp -r ~/kachaka-api/ros2/kachaka_interfaces .
 cp -r ~/kachaka-api/ros2/demos/kachaka_follow .
@@ -18,14 +18,13 @@ cd ~/ros2_ws
 colcon build
 ```
 
-# Execution
+## Execution
 
 * Open another terminal and start the ROS2 bridge.
 
 ```
-cd ~/kachaka-api/ros2_bridge
+cd ~/kachaka-api/tools/ros2_bridge
 ./start_bridge.sh <Kachaka's IP>
-
 ```
 
 * Next, run the following command.
@@ -35,4 +34,3 @@ cd ~/ros2_ws
 source install/setup.bash
 ros2 run kachaka_follow follow
 ```
-

--- a/ros2/demos/kachaka_follow/kachaka_follow/follow.py
+++ b/ros2/demos/kachaka_follow/kachaka_follow/follow.py
@@ -14,17 +14,19 @@ ANGULAR_TOLERANCE = 0.8
 class Follower(Node):
     def __init__(self) -> None:
         super().__init__("follow")
+        qos_profile = rclpy.qos.QoSProfile(depth=10)
+        qos_profile.reliability = rclpy.qos.QoSReliabilityPolicy.BEST_EFFORT
         self._publisher = self.create_publisher(
             Twist, "/kachaka/manual_control/cmd_vel", 10
         )
         self._lidar_subscriber = self.create_subscription(
-            LaserScan, "/kachaka/lidar/scan", self._laser_scan_callback, 10
+            LaserScan, "/kachaka/lidar/scan", self._laser_scan_callback, qos_profile
         )
         self._object_detection_subscriber = self.create_subscription(
             ObjectDetectionListStamped,
             "/kachaka/object_detection/result",
             self._object_detection_callback,
-            10,
+            qos_profile,
         )
         self._timer = self.create_timer(0.1, self._publish_cmd_vel)
         self._cmd_vel = Twist()


### PR DESCRIPTION
`ros2/demos/kachaka_follow`で以下の問題を修正しました。

- QoS profileが不適切でkachaka_grpc_ros2_bridgeで発行されるトピックが購読できない問題の修正 <https://github.com/pf-robotics/kachaka-api/commit/c127c648845e25b66b865194d29e4d68995338d4>
- READMEの記述の誤りを修正 <https://github.com/pf-robotics/kachaka-api/commit/9b126909f456ab0686e8a71ba5df91b45f5d5a2a>