### PR TITLE
Add npm min-release-age to .npmrc for supply chain attack mitigation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## 推奨：自衛手段の整備

3月中のサプライチェーン攻撃は、Trivy、LiteLLM、Telnyx、そして今回の axios へと波及しています。次にどのパッケージが狙われるかは予測できないため、可能な限りの自衛を推奨します。

### npm の `min-release-age`

npm v11 以降では `.npmrc` に `min-release-age` を設定することで、公開から一定期間が経過していないバージョンのインストールを抑止できます。この状況下では **7 日程度**を推奨します。急ぐ場合でも 3 日程度は確保してください。

今回の axios のようにエコシステム全体で騒がれる規模の侵害は、数時間でテイクダウンされます。しかし、より小規模なパッケージや依存の深い階層で起こる侵害は発見が遅れ、数日間以上にわたって npm 上に残存することもあります。検疫期間はそうした「気づかれにくい侵害」に対してこそ効果を発揮します。

```ini
# .npmrc
min-release-age=7
```

### pnpm の `trustPolicy: no-downgrade`

pnpm には `trustPolicy: no-downgrade` という仕様があり、パッケージの信頼度が下がるような更新（例：OIDC による trusted publishing から手動パブリッシュへの切り替え）をブロックできます。今回の axios の問題の2バージョンは、この設定を有効化していればブロックされます。ただし、今後 axios 経由で他のパッケージ（例えば axios の依存パッケージ）が侵害された場合に、`trustPolicy: no-downgrade` でブロックできないケースが存在する可能性はあります。