### PR TITLE
Allow gRPC channel options in clients

### DIFF
--- a/python/kachaka_api/__init__.py
+++ b/python/kachaka_api/__init__.py
@@ -10,6 +10,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Sequence
+
 from . import aio  # noqa: F401
 from .base import KachakaApiClientBase
 from .generated import kachaka_api_pb2 as pb2  # noqa: F401
@@ -19,5 +21,9 @@ from .util import layout as layout_util  # noqa: F401
 
 
 class KachakaApiClient(KachakaApiClientBase):
-    def __init__(self, target="100.94.1.1:26400") -> None:
-        super().__init__(target)
+    def __init__(
+        self,
+        target: str = "100.94.1.1:26400",
+        options: Sequence[tuple[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(target, options=options)

--- a/python/kachaka_api/aio/__init__.py
+++ b/python/kachaka_api/aio/__init__.py
@@ -14,12 +14,14 @@ from __future__ import annotations
 
 import asyncio
 from typing import (
+    Any,
     AsyncGenerator,
     Awaitable,
     Callable,
     Generic,
     ParamSpec,
     Protocol,
+    Sequence,
     TypeVar,
 )
 
@@ -98,8 +100,12 @@ class TupleResponseHandler(ResponseHandler[T, U], Generic[T, U, P]):
 
 
 class KachakaApiClient(KachakaApiClientBase):
-    def __init__(self, target: str = "100.94.1.1:26400") -> None:
-        super().__init__(target)
+    def __init__(
+        self,
+        target: str = "100.94.1.1:26400",
+        options: Sequence[tuple[str, Any]] | None = None,
+    ) -> None:
+        super().__init__(target, options=options)
         self._running = True
 
         self.png_map = ResponseHandler[pb2.GetPngMapResponse, pb2.Map](

--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -12,7 +12,7 @@
 
 import json
 import socket
-from typing import AsyncIterator, Iterator, NamedTuple, TypedDict
+from typing import Any, AsyncIterator, Iterator, NamedTuple, Sequence, TypedDict
 
 import grpc
 from google._upb._message import RepeatedCompositeContainer
@@ -56,11 +56,17 @@ def _resolve_target(target: str) -> str | None:
 
 
 class KachakaApiClientBase:
-    def __init__(self, target: str = "100.94.1.1:26400") -> None:
+    def __init__(
+        self,
+        target: str = "100.94.1.1:26400",
+        options: Sequence[tuple[str, Any]] | None = None,
+    ) -> None:
         target_resolved = _resolve_target(target)
         if target_resolved is None:
             raise ValueError(f"Invalid target: {target}")
-        self.stub = KachakaApiStub(grpc.aio.insecure_channel(target_resolved))
+        self.stub = KachakaApiStub(
+            grpc.aio.insecure_channel(target_resolved, options=options)
+        )
         self.resolver = ShelfLocationResolver()
 
     async def get_robot_serial_number(self) -> str:

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -15,7 +15,7 @@
 
 import json
 import socket
-from typing import Iterator, NamedTuple, TypedDict
+from typing import Any, Iterator, NamedTuple, Sequence, TypedDict
 
 import grpc
 from google._upb._message import RepeatedCompositeContainer
@@ -59,11 +59,17 @@ def _resolve_target(target: str) -> str | None:
 
 
 class KachakaApiClientBase:
-    def __init__(self, target: str = "100.94.1.1:26400") -> None:
+    def __init__(
+        self,
+        target: str = "100.94.1.1:26400",
+        options: Sequence[tuple[str, Any]] | None = None,
+    ) -> None:
         target_resolved = _resolve_target(target)
         if target_resolved is None:
             raise ValueError(f"Invalid target: {target}")
-        self.stub = KachakaApiStub(grpc.insecure_channel(target_resolved))
+        self.stub = KachakaApiStub(
+            grpc.insecure_channel(target_resolved, options=options)
+        )
         self.resolver = ShelfLocationResolver()
 
     def get_robot_serial_number(self) -> str:

--- a/python/kachaka_api/util/vision.py
+++ b/python/kachaka_api/util/vision.py
@@ -1,7 +1,7 @@
 import contextlib
 import io
 import threading
-from typing import Generator, List, Optional
+from typing import Any, Generator, List, Optional, Sequence, Tuple
 
 import grpc
 import numpy as np
@@ -16,8 +16,14 @@ OBJECT_LABEL_COLOR = ["pink", "green", "blue", "cyan", "red"]
 
 
 class LaserScanActivator:
-    def __init__(self, target: str = "100.94.1.1:26400") -> None:
-        self._stub = KachakaApiStub(grpc.insecure_channel(target))
+    def __init__(
+        self,
+        target: str = "100.94.1.1:26400",
+        options: Optional[Sequence[Tuple[str, Any]]] = None,
+    ) -> None:
+        self._stub = KachakaApiStub(
+            grpc.insecure_channel(target, options=options)
+        )
         self._thread: Optional[threading.Thread] = None
         self._disposing = threading.Event()
 


### PR DESCRIPTION
# 概要

Kachaka API client に任意の gRPC channel `options` を渡せるようにしました。
