### PR TITLE
fix(kachaka_description): rename laser_frame link to laser_link

### DIFF
--- a/ros2/demos/kachaka_nav2_bringup/rviz/kachaka-nav.rviz
+++ b/ros2/demos/kachaka_nav2_bringup/rviz/kachaka-nav.rviz
@@ -104,7 +104,7 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        laser_frame:
+        laser_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -306,6 +306,8 @@ Visualization Manager:
           Value: true
         laser_frame:
           Value: true
+        laser_link:
+          Value: true
         layout_offset:
           Value: true
         lidar_center_frame:
@@ -467,9 +469,10 @@ Visualization Manager:
                   {}
                 imu_link:
                   {}
-                laser_frame:
-                  lidar_center_frame:
-                    {}
+                laser_link:
+                  laser_frame:
+                    lidar_center_frame:
+                      {}
                 tof_link:
                   tof_camera:
                     {}

--- a/ros2/kachaka_description/config/display.rviz
+++ b/ros2/kachaka_description/config/display.rviz
@@ -103,7 +103,7 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        laser_frame:
+        laser_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -140,7 +140,7 @@ Visualization Manager:
           Value: true
         imu_link:
           Value: true
-        laser_frame:
+        laser_link:
           Value: true
         tof_link:
           Value: true
@@ -164,7 +164,7 @@ Visualization Manager:
               {}
             imu_link:
               {}
-            laser_frame:
+            laser_link:
               {}
             tof_link:
               {}

--- a/ros2/kachaka_description/config/kachaka.rviz
+++ b/ros2/kachaka_description/config/kachaka.rviz
@@ -109,7 +109,7 @@ Visualization Manager:
           Alpha: 1
           Show Axes: false
           Show Trail: false
-        laser_frame:
+        laser_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false

--- a/ros2/kachaka_description/urdf/_kachaka.urdf.xacro
+++ b/ros2/kachaka_description/urdf/_kachaka.urdf.xacro
@@ -119,11 +119,11 @@
     <joint name="lidar_joint"
           type="fixed">
       <parent link="base_link" />
-      <child link="laser_frame" />
+      <child link="laser_link" />
       <origin rpy="0 0 ${PI / 2.0}"
               xyz="0.156 0 0.1049" />
     </joint>
-    <link name="laser_frame" />
+    <link name="laser_link" />
 
     <!-- Camera(front) -->
     <joint name="camera_front_joint"


### PR DESCRIPTION
## 概要

`kachaka_description` の URDF が定義しているレーザーのリンク名を、実機が publish する TF ツリーに合わせて `laser_frame` から `laser_link` にリネームします。

従来は URDF が `base_link` の子として `laser_frame` を定義していたため、実機側の static TF が publish する同名フレームと親が食い違い、TF ツリー上でレーザーの位置が一意に定まらない状態でした。

## 変更内容

- URDF のレーザー用 joint / link の名前を `laser_link` に変更し、実機の TF ツリーのセンサ系チェーンに接続されるようにしました。
- 併せて RViz config のリンク名・frame 一覧・TF Tree 表示をリネーム後の構成に合わせて更新しました。

## 検証

```bash
source /opt/ros/jazzy/setup.bash
xacro ros2/kachaka_description/robot/kachaka.urdf.xacro
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
```

## PRチェーン

- 👉 #240 fix(kachaka_description): rename laser_frame link to laser_link
- #241 feat(kachaka_grpc_ros2_bridge): add publish_map_tf parameter to dynamic tf bridge
