### PR TITLE
feat(kachaka_grpc_ros2_bridge): add publish_map_tf parameter to dynamic tf bridge

### DIFF
--- a/docs/ROS2.md
+++ b/docs/ROS2.md
@@ -13,6 +13,7 @@
 - [他のROS 2パッケージと連携する](#他のros-2パッケージと連携する)
   - [kachaka_interfaces, kachaka_descriptionのビルド](#kachaka_interfaces-kachaka_descriptionのビルド)
   - [RViz2による可視化](#rviz2による可視化)
+  - [外部の自己位置推定ノードと連携する](#外部の自己位置推定ノードと連携する)
 - [サンプルコード](#サンプルコード)
 - [Dockerイメージを自分でビルドする](#dockerイメージを自分でビルドする)
 
@@ -104,6 +105,27 @@ source install/setup.bash
 cd src/kachaka_description/config
 rviz2 -d kachaka.rviz
 ```
+
+### 外部の自己位置推定ノードと連携する
+
+* ブリッジは既定でカチャカ本体の自己位置推定結果を`map -> odom`のTFとして出力します。
+* AMCLやemcl2など外部の自己位置推定ノードを併用する場合、同じ`map -> odom`を2つのノードが出力することになり、TFが競合して正しく動作しません。
+* この場合は`PUBLISH_MAP_TF=false`を指定してブリッジを起動すると、`map`を親とする動的TFを出力しなくなります。
+
+```bash
+cd ~/kachaka-api/tools/ros2_bridge
+PUBLISH_MAP_TF=false ./start_bridge.sh <カチャカのIPアドレス>
+```
+
+* Dockerを使わずにlaunchファイルを直接実行する場合は、`publish_map_tf`引数を指定してください。
+
+```bash
+ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml publish_map_tf:=false
+```
+
+* 外部の自己位置推定ノードには、ブリッジが出力する`/kachaka/lidar/scan`と`/kachaka/mapping/map`を入力として与えます。
+* なお`/tf_static`で出力される目的地(`L01`など)のTFは`map`を親としたままです。これらは子フレームが競合しないためTFツリーは壊れませんが、外部の自己位置推定ノードがカチャカと異なる地図を使う場合は目的地の位置がずれる点に注意してください。
+* `PUBLISH_MAP_TF=false`の場合、カチャカ本体の自己位置推定結果はROS 2側から取得できなくなります。
 
 ## サンプルコード
 

--- a/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
+++ b/ros2/kachaka_grpc_ros2_bridge/launch/grpc_ros2_bridge.launch.xml
@@ -6,6 +6,8 @@
        default="$(env FRAME_PREFIX)" />
   <arg name="server_uri"
        default="localhost:2021" />
+  <arg name="publish_map_tf"
+       default="true" />
   <node_container pkg="rclcpp_components"
                   exec="component_container_mt"
                   name="grpc_ros2_bridge_container"
@@ -199,6 +201,9 @@
              value="$(var frame_prefix)" />
       <param name="server_uri"
              value="$(var server_uri)" />
+      <param name="publish_map_tf"
+             value="$(var publish_map_tf)"
+             type="bool" />
       <extra_arg name="use_intra_process_comms"
                  value="false" />
     </composable_node>

--- a/ros2/kachaka_grpc_ros2_bridge/src/component/dynamic_tf_component.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/component/dynamic_tf_component.cpp
@@ -34,12 +34,18 @@ class DynamicTfComponent : public rclcpp::Node {
 
     this->declare_parameter("frame_prefix", "");
     frame_prefix_ = this->get_parameter("frame_prefix").as_string();
+    this->declare_parameter("publish_map_tf", true);
+    publish_map_tf_ = this->get_parameter("publish_map_tf").as_bool();
     stub_ = GetSharedStub(declare_parameter("server_uri", ""));
 
     RCLCPP_INFO(this->get_logger(), "get stub");
 
-    dynamic_tf_client_ =
-        std::make_unique<TfStreamClient>(frame_prefix_, stub_, this);
+    if (!publish_map_tf_) {
+      RCLCPP_INFO(this->get_logger(), "map tf is not published");
+    }
+
+    dynamic_tf_client_ = std::make_unique<TfStreamClient>(
+        frame_prefix_, publish_map_tf_, stub_, this);
 
     dynamic_tf_client_->ReadStream();
     RCLCPP_INFO(this->get_logger(), "start read dynamic tf");
@@ -51,6 +57,7 @@ class DynamicTfComponent : public rclcpp::Node {
 
  private:
   std::string frame_prefix_;
+  bool publish_map_tf_{true};
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   std::unique_ptr<TfStreamClient> dynamic_tf_client_;
 };

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
@@ -22,7 +22,7 @@
 namespace {
 constexpr char kMapFrameId[] = "map";
 
-// 変換結果が1件以上ある場合にtrueを返す。
+// Returns true if the converted message has at least one transform.
 bool ConvertGrpcTfToRosTf(
     const kachaka_api::GetDynamicTransformResponse& grpc_msg,
     tf2_msgs::msg::TFMessage* msg, const std::string& frame_prefix = "",
@@ -30,7 +30,7 @@ bool ConvertGrpcTfToRosTf(
   msg->transforms.clear();
   msg->transforms.reserve(grpc_msg.transforms_size());
   for (const auto& transform_grpc : grpc_msg.transforms()) {
-    // frame_prefixの有無に依存しないようgRPC側のframe_idで判定する。
+    // Check the frame_id on the gRPC side not to depend on frame_prefix.
     if (!publish_map_tf && transform_grpc.header().frame_id() == kMapFrameId) {
       continue;
     }

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.cpp
@@ -20,12 +20,21 @@
 #include "kachaka-api.grpc.pb.h"
 
 namespace {
+constexpr char kMapFrameId[] = "map";
+
+// 変換結果が1件以上ある場合にtrueを返す。
 bool ConvertGrpcTfToRosTf(
     const kachaka_api::GetDynamicTransformResponse& grpc_msg,
-    tf2_msgs::msg::TFMessage* msg, const std::string& frame_prefix = "") {
+    tf2_msgs::msg::TFMessage* msg, const std::string& frame_prefix = "",
+    const bool publish_map_tf = true) {
   msg->transforms.clear();
   msg->transforms.reserve(grpc_msg.transforms_size());
   for (const auto& transform_grpc : grpc_msg.transforms()) {
+    // frame_prefixの有無に依存しないようgRPC側のframe_idで判定する。
+    if (!publish_map_tf && transform_grpc.header().frame_id() == kMapFrameId) {
+      continue;
+    }
+
     geometry_msgs::msg::TransformStamped transform_ros;
     kachaka::grpc_ros2_bridge::converter::ConvertGrpcHeaderToRos2Header(
         transform_grpc.header(), &(transform_ros.header), frame_prefix);
@@ -42,7 +51,7 @@ bool ConvertGrpcTfToRosTf(
 
     msg->transforms.push_back(transform_ros);
   }
-  return true;
+  return !msg->transforms.empty();
 }
 
 }  // namespace
@@ -50,9 +59,10 @@ bool ConvertGrpcTfToRosTf(
 namespace kachaka::grpc_ros2_bridge {
 
 TfStreamClient::TfStreamClient(
-    std::string frame_prefix,
+    std::string frame_prefix, bool publish_map_tf,
     std::shared_ptr<kachaka_api::KachakaApi::Stub> stub, rclcpp::Node* node)
     : frame_prefix_(std::move(frame_prefix)),
+      publish_map_tf_(publish_map_tf),
       stub_(stub),
       node_(node),
       publisher_(node->create_publisher<tf2_msgs::msg::TFMessage>(
@@ -69,8 +79,9 @@ void TfStreamClient::ReadStream() {
 
   while (reader->Read(&response)) {
     tf2_msgs::msg::TFMessage msg;
-    ConvertGrpcTfToRosTf(response, &msg, frame_prefix_);
-    publisher_->publish(msg);
+    if (ConvertGrpcTfToRosTf(response, &msg, frame_prefix_, publish_map_tf_)) {
+      publisher_->publish(msg);
+    }
   }
   RCLCPP_INFO(node_->get_logger(), "dynamic tf server is stopped.");
 }

--- a/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.hpp
+++ b/ros2/kachaka_grpc_ros2_bridge/src/dynamic_tf_bridge.hpp
@@ -21,13 +21,14 @@ namespace kachaka::grpc_ros2_bridge {
 
 class TfStreamClient {
  public:
-  TfStreamClient(std::string frame_prefix,
+  TfStreamClient(std::string frame_prefix, bool publish_map_tf,
                  std::shared_ptr<kachaka_api::KachakaApi::Stub> stub,
                  rclcpp::Node* node);
   void ReadStream();
 
  private:
   std::string frame_prefix_;
+  bool publish_map_tf_;
   std::shared_ptr<kachaka_api::KachakaApi::Stub> stub_{nullptr};
   rclcpp::Node* node_;
   typename rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr publisher_;

--- a/tools/ros2_bridge/docker-compose.yaml
+++ b/tools/ros2_bridge/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - GROUP_ID
     user: "${USER_ID}:${GROUP_ID}"
     command: >
-      ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml server_uri:=${API_GRPC_BRIDGE_SERVER_URI} namespace:=${NAMESPACE}
+      ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml server_uri:=${API_GRPC_BRIDGE_SERVER_URI} namespace:=${NAMESPACE} publish_map_tf:=${PUBLISH_MAP_TF:-true}
   kachaka_follow:
     image: "asia-northeast1-docker.pkg.dev/kachaka-api/docker/kachaka-grpc-ros2-bridge:${TAG}"
     network_mode: "host"

--- a/tools/ros2_bridge/start_bridge.sh
+++ b/tools/ros2_bridge/start_bridge.sh
@@ -8,6 +8,8 @@ cd "${DOCKER_COMPOSE_DIR}"
 usage() {
     echo "Usage: $0 KACHAKA_IP_ADRESS [KACHAKA_NAME] [Option]"
     echo "  -d    daemonize"
+    echo "Environment variables:"
+    echo "  PUBLISH_MAP_TF=false    do not publish tf whose parent frame is map (default: true)"
     exit 1
 }
 
@@ -26,9 +28,11 @@ fi
 USER_ID="$(id -u)"
 GROUP_ID="$(id -g)"
 GRPC_PORT=26400
+PUBLISH_MAP_TF="${PUBLISH_MAP_TF:-true}"
 
 export USER_ID
 export GROUP_ID
+export PUBLISH_MAP_TF
 
 KACHAKA_IP=$1
 


### PR DESCRIPTION
## 概要

外部の自己位置推定ノードと併用できるように、ブリッジが publish する動的 TF から `map` を親とするものを除外する起動パラメータ `publish_map_tf` を追加します。

ブリッジは起動すると常にカチャカ本体の推定結果である `map -> odom` を publish するため、手元で AMCL / emcl2 などの Localization ノードを動かすと同じ親子関係を 2 つのノードが publish する状態になり、TF ツリーが競合して連携できませんでした。本体側は値が変わらなくても約 30 Hz で再送し続けるため、更新レートの低い外部ノードの推定結果が上書きされてしまいます。

## 変更内容

- `dynamic_tf` に bool パラメータ `publish_map_tf` を追加しました。既定値は `true` で、従来どおり本体側の `map -> odom` を publish します。
- `false` のときは、親フレームが `map` の動的 TF を publish 対象から除外します。判定は gRPC メッセージ側のフレーム名に対して行うため、`frame_prefix` の指定に影響されません。除外の結果 transform が 1 件も残らない場合は空の `TFMessage` を publish しません。
- launch 引数として指定できるようにし、配布 Docker イメージの利用者が再ビルドせずに切り替えられるよう起動スクリプト側からも渡せるようにしました。
- 外部の自己位置推定ノードと連携する手順をドキュメントに追記しました。

## 検証

```bash
# build (ROS 2 Jazzy)
source /opt/ros/jazzy/setup.bash
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

# launch with the default (existing) behavior and check the TF tree
ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml \
  server_uri:=<KACHAKA_IP>:26400
ros2 run tf2_tools view_frames

# stop it, then relaunch with map tf disabled and check the TF tree again
ros2 launch kachaka_grpc_ros2_bridge grpc_ros2_bridge.launch.xml \
  server_uri:=<KACHAKA_IP>:26400 publish_map_tf:=false
ros2 run tf2_tools view_frames
```

既定では `map -> odom -> base_footprint` が構成され、`publish_map_tf:=false` では `map` を親とする動的 TF が流れず `odom` がツリーのルートになります。後者の状態で外部の自己位置推定ノードを `/kachaka/lidar/scan` と `/kachaka/mapping/map` に接続して起動し、`map -> odom` が外部ノードのみから publish される状態で連携できることを確認しました。

## PRチェーン

- #240 fix(kachaka_description): rename laser_frame link to laser_link
- 👉 #241 feat(kachaka_grpc_ros2_bridge): add publish_map_tf parameter to dynamic tf bridge
