### PR TITLE
chore(lint): pin tomlkit to avoid pysen dumper failure

### DIFF
--- a/tools/lint/requirements.txt
+++ b/tools/lint/requirements.txt
@@ -12,3 +12,4 @@ protobuf==4.23.4
 pysen-plugins==2023.5.22
 pysen==0.10.4
 shellcheck-py==0.8.0.4
+tomlkit==0.15.0


### PR DESCRIPTION
## 概要

lint CI が次のエラーで失敗する状態を直します。

```
RuntimeError: got an unexpected error while creating pyproject.toml: Comment cannot contain line breaks
```

`tools/lint/requirements.txt` は pysen を pin していますが、その推移的依存である `tomlkit` は pin していないため、CI は常に最新版を取得します。`tomlkit` 0.15.1 は改行を含むコメントを拒否するようになり、pysen 0.10.4 が設定ファイル出力時に渡す 2 行のコメントで例外になります。lint workflow の直近の成功は 2026-07-09 で、その後のリリースで壊れたものです。変更内容とは無関係に、`main` およびすべての PR で発生します。

この PR は #240 / #241 とは独立しており、`main` に入れば両 PR の CI も再実行で通ります。

## 変更内容

- lint の依存関係に `tomlkit` を明示的に追加し、pysen が動作するバージョンに固定しました。

## 検証

```bash
python3 -m venv /tmp/lintvenv
/tmp/lintvenv/bin/pip install pysen==0.10.4 pysen-plugins==2023.5.22 \
  black==23.7.0 flake8==6.1.0 isort==5.12.0

/tmp/lintvenv/bin/pip install tomlkit==0.15.1
/tmp/lintvenv/bin/pysen run lint

/tmp/lintvenv/bin/pip install tomlkit==0.15.0
/tmp/lintvenv/bin/pysen run lint
```

0.15.1 では CI と同じ `Comment cannot contain line breaks` で中断し、0.15.0 では pysen が設定ファイルの出力を終えて各 linter の実行まで進みます。

## PRチェーン

- 👉 #242 chore(lint): pin tomlkit to avoid pysen dumper failure
