### PR TITLE
Return the matched result from start_command

### DIFF
--- a/python/kachaka_api/aio/base.py
+++ b/python/kachaka_api/aio/base.py
@@ -251,7 +251,7 @@ class KachakaApiClientBase:
             )
             if command_result_response.command_id == response.command_id:
                 break
-        return (await self.get_last_command_result())[0]
+        return command_result_response.result
 
     async def move_shelf(
         self,

--- a/python/kachaka_api/base.py
+++ b/python/kachaka_api/base.py
@@ -246,7 +246,7 @@ class KachakaApiClientBase:
             )
             if command_result_response.command_id == response.command_id:
                 break
-        return (self.get_last_command_result())[0]
+        return command_result_response.result
 
     def move_shelf(
         self,


### PR DESCRIPTION
## Summary

Return the result that was already matched by command ID in the synchronous and
asynchronous `start_command` implementations.

## Problem

After `GetLastCommandResult` returns the response whose command ID matches the
command started by this call, the current implementation discards that response
and performs another cursorless lookup. If another command finishes between the
two lookups, `start_command` can return the newer command's result instead.

## Change

Return `command_result_response.result` directly after the command ID matches.
This also avoids one unnecessary RPC. The synchronous client was regenerated
from the asynchronous source with the repository's generation script.

## Verification

A deterministic local stub made command A complete successfully and then made
command B the latest failed result before the second lookup. Before this change,
both the synchronous and asynchronous clients returned command B's result.
After this change, both return command A's matched result (2 tests passed).
